### PR TITLE
Fix spacing in the comparison description text

### DIFF
--- a/web/components/page-shell.tsx
+++ b/web/components/page-shell.tsx
@@ -60,7 +60,7 @@ export function PageShell({
             The Browser Arena
           </h1>
           <p className="mt-0 sm:mt-3 sm:max-w-2xl text-[0.78rem] sm:text-sm leading-relaxed text-muted-foreground">
-            Comparing cloud browser infrastructure providers
+            Comparing cloud browser infrastructure providers{' '}
             <br className="sm:hidden" />
             on speed, reliability, and cost.{' '}
             <br className="hidden sm:block" />


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `{' '}` JSX expression after "Comparing cloud browser infrastructure providers" in the description paragraph of `page-shell.tsx`. Without the space, on screen sizes where the `<br className="sm:hidden" />` is hidden, the two text segments would run together without a word break.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-character whitespace fix with no logic or security implications.

The change is minimal (one added JSX whitespace token), directly addresses a visible text-rendering bug on desktop, and introduces no new logic, dependencies, or side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/page-shell.tsx | Adds a JSX whitespace expression after "providers" to prevent text from running together on larger screens where the mobile-only `<br>` is hidden. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix spacing in the comparison descriptio..."](https://github.com/nottelabs/browserarena/commit/d78a2fa6f4dda81a9994eb40f98ffdb27c9d9acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28046667)</sub>

<!-- /greptile_comment -->