### PR TITLE
Add historical benchmark charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import {
+  loadHistoricalLeaderboard,
   loadLeaderboard,
   type PercentileType,
   type SortByType,
@@ -8,6 +9,7 @@ import {
 import { LeaderboardTable } from "@/components/leaderboard-table";
 import { HelloBrowserControls } from "@/components/benchmark-controls";
 import { PageShell } from "@/components/page-shell";
+import { HistoryCharts } from "@/components/history-charts";
 
 const VALID_PERCENTILES: PercentileType[] = ["median", "p90", "p95"];
 const VALID_SORT: SortByType[] = ["latency", "reliability", "price"];
@@ -46,6 +48,7 @@ export default async function Home({
     sortBy,
     concurrency
   );
+  const history = await loadHistoricalLeaderboard("hello-browser", effectiveConcurrency);
 
 
   return (
@@ -72,6 +75,12 @@ export default async function Home({
           </div>
         )}
       </div>
+
+      <HistoryCharts
+        history={history}
+        percentile={percentile}
+        initialProvider={providers[0]?.provider}
+      />
 
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <span className="text-sm text-muted-foreground">

--- a/web/components/history-charts.tsx
+++ b/web/components/history-charts.tsx
@@ -15,7 +15,6 @@ import {
   ChartLegend,
   ChartLegendContent,
   ChartTooltip,
-  ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
 import type {
@@ -78,6 +77,8 @@ const PHASE_CONFIG = {
     color: "#76B7B2",
   },
 } satisfies ChartConfig;
+
+const PHASE_ORDER_TOP_DOWN = ["release", "goto", "connect", "create"];
 
 const PROVIDER_COLORS = [
   "#4E79A7",
@@ -169,6 +170,14 @@ type ValueScoreTooltipItem = {
   payload?: { date?: string };
 };
 
+type BreakdownTooltipItem = {
+  dataKey?: string | number;
+  name?: string | number;
+  value?: unknown;
+  color?: string;
+  payload?: { date?: string };
+};
+
 function ValueScoreTooltip({
   active,
   payload,
@@ -204,6 +213,61 @@ function ValueScoreTooltip({
               </span>
               <span className="font-mono font-medium text-foreground tabular-nums">
                 {formatScore(item.value)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function BreakdownTooltip({
+  active,
+  payload,
+  config,
+}: {
+  active?: boolean;
+  payload?: BreakdownTooltipItem[];
+  config: ChartConfig;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const phaseRank = new Map(
+    PHASE_ORDER_TOP_DOWN.map((key, index) => [key, index])
+  );
+  const rows = payload
+    .filter((item): item is BreakdownTooltipItem & { value: number } =>
+      typeof item.value === "number"
+    )
+    .sort((a, b) => {
+      const aKey = String(a.dataKey ?? a.name ?? "");
+      const bKey = String(b.dataKey ?? b.name ?? "");
+      return (phaseRank.get(aKey) ?? 99) - (phaseRank.get(bKey) ?? 99);
+    });
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="grid min-w-[10rem] items-start gap-1.5 rounded-none border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <div className="font-medium">{rows[0]?.payload?.date}</div>
+      <div className="grid gap-1.5">
+        {rows.map((item) => {
+          const key = String(item.dataKey ?? item.name ?? "");
+          return (
+            <div key={key} className="flex w-full items-center gap-2">
+              <div
+                className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor:
+                    item.color ||
+                    ("color" in (config[key] ?? {}) ? config[key]?.color : undefined),
+                }}
+              />
+              <span className="min-w-0 flex-1 text-muted-foreground">
+                {config[key]?.label ?? key}
+              </span>
+              <span className="font-mono font-medium text-foreground tabular-nums">
+                {formatMs(item.value)}
               </span>
             </div>
           );
@@ -552,20 +616,7 @@ export function HistoryCharts({
                 tickFormatter={(value) => `${(Number(value) / 1000).toFixed(1)}s`}
               />
               <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    className="rounded-none"
-                    labelFormatter={(_, payload) => payload?.[0]?.payload?.date}
-                    formatter={(value, name) => (
-                      <div className="flex w-full items-center justify-between gap-4">
-                        <span className="text-muted-foreground capitalize">{name}</span>
-                        <span className="font-mono text-foreground tabular-nums">
-                          {formatMs(value)}
-                        </span>
-                      </div>
-                    )}
-                  />
-                }
+                content={<BreakdownTooltip config={PHASE_CONFIG} />}
               />
               <ChartLegend content={<ChartLegendContent />} />
               {(["create", "connect", "goto", "release"] as const).map((key, index, arr) => (

--- a/web/components/history-charts.tsx
+++ b/web/components/history-charts.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import type {
+  HistoricalLeaderboardResult,
+  HistoricalProviderPoint,
+  PercentileType,
+} from "@/lib/data-shared";
+
+const HISTORY_START_DATE = "2026-05-15";
+const HISTORY_DATE_CAP = 7;
+const BREAKDOWN_AXIS_LEAD_MS = 360;
+
+type PhaseMetricKeys = {
+  create: keyof HistoricalProviderPoint;
+  connect: keyof HistoricalProviderPoint;
+  goto: keyof HistoricalProviderPoint;
+  release: keyof HistoricalProviderPoint;
+  total: keyof HistoricalProviderPoint;
+};
+
+const PHASE_KEYS: Record<PercentileType, PhaseMetricKeys> = {
+  median: {
+    create: "medianCreationMs",
+    connect: "medianConnectMs",
+    goto: "medianGotoMs",
+    release: "medianReleaseMs",
+    total: "totalTimeMs",
+  },
+  p90: {
+    create: "p90CreationMs",
+    connect: "p90ConnectMs",
+    goto: "p90GotoMs",
+    release: "p90ReleaseMs",
+    total: "p90TotalMs",
+  },
+  p95: {
+    create: "p95CreationMs",
+    connect: "p95ConnectMs",
+    goto: "p95GotoMs",
+    release: "p95ReleaseMs",
+    total: "p95TotalMs",
+  },
+};
+
+const PHASE_CONFIG = {
+  create: {
+    label: "Create",
+    color: "#4E79A7",
+  },
+  connect: {
+    label: "Connect",
+    color: "#F28E2B",
+  },
+  goto: {
+    label: "Goto",
+    color: "#E15759",
+  },
+  release: {
+    label: "Release",
+    color: "#76B7B2",
+  },
+} satisfies ChartConfig;
+
+const PROVIDER_COLORS = [
+  "#4E79A7",
+  "#F28E2B",
+  "#E15759",
+  "#76B7B2",
+  "#59A14F",
+  "#EDC948",
+  "#B07AA1",
+  "#FF9DA7",
+  "#9C755F",
+  "#BAB0AC",
+];
+
+const VALUE_ANCHORS = {
+  latency: { floor: 10_000, ceiling: 0 },
+  reliability: { floor: 90, ceiling: 100 },
+  cost: { floor: 0.20, ceiling: 0 },
+};
+
+function formatDateLabel(ymd: string): string {
+  const [, month, day] = ymd.split("-");
+  return month && day ? `${month}/${day}` : ymd;
+}
+
+function formatMs(value: unknown): string {
+  return typeof value === "number"
+    ? `${Math.round(value).toLocaleString("en-US")} ms`
+    : "";
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+function computeValueScore({
+  latencyMs,
+  successRate,
+  pricePerHour,
+}: {
+  latencyMs: number;
+  successRate: number;
+  pricePerHour: number | null;
+}): number {
+  const latencyRange = VALUE_ANCHORS.latency.floor - VALUE_ANCHORS.latency.ceiling;
+  const reliabilityRange = VALUE_ANCHORS.reliability.ceiling - VALUE_ANCHORS.reliability.floor;
+  const costRange = VALUE_ANCHORS.cost.floor - VALUE_ANCHORS.cost.ceiling;
+
+  const normalizedLatency = clamp01(
+    (VALUE_ANCHORS.latency.floor - latencyMs) / latencyRange
+  );
+  const normalizedReliability = clamp01(
+    (successRate - VALUE_ANCHORS.reliability.floor) / reliabilityRange
+  );
+  const normalizedCost =
+    pricePerHour != null
+      ? clamp01((VALUE_ANCHORS.cost.floor - pricePerHour) / costRange)
+      : 0;
+
+  return (normalizedLatency + normalizedReliability + normalizedCost) / 3;
+}
+
+function formatScore(value: unknown): string {
+  return typeof value === "number" ? value.toFixed(3) : "";
+}
+
+function computeBreakdownDomain(
+  series: { points: HistoricalProviderPoint[] } | undefined,
+  keys: PhaseMetricKeys
+): [number, number] {
+  if (!series) return [0, 1000];
+  const max = Math.max(
+    ...series.points.map((point) =>
+      (point[keys.create] as number) +
+      (point[keys.connect] as number) +
+      (point[keys.goto] as number) +
+      (point[keys.release] as number)
+    )
+  );
+  if (!Number.isFinite(max) || max <= 0) return [0, 1000];
+  return [0, Math.ceil((max * 1.08) / 100) * 100];
+}
+
+type ValueScoreTooltipItem = {
+  dataKey?: string | number;
+  name?: string | number;
+  value?: unknown;
+  color?: string;
+  payload?: { date?: string };
+};
+
+function ValueScoreTooltip({
+  active,
+  payload,
+  config,
+}: {
+  active?: boolean;
+  payload?: ValueScoreTooltipItem[];
+  config: ChartConfig;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const rows = payload
+    .filter((item): item is ValueScoreTooltipItem & { value: number } =>
+      typeof item.value === "number"
+    )
+    .sort((a, b) => b.value - a.value);
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="grid min-w-[10rem] items-start gap-1.5 rounded-none border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <div className="font-medium">{rows[0]?.payload?.date}</div>
+      <div className="grid gap-1.5">
+        {rows.map((item) => {
+          const key = String(item.dataKey ?? item.name ?? "");
+          return (
+            <div key={key} className="flex w-full items-center gap-2">
+              <div
+                className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: item.color }}
+              />
+              <span className="min-w-0 flex-1 text-muted-foreground">
+                {config[key]?.label ?? key}
+              </span>
+              <span className="font-mono font-medium text-foreground tabular-nums">
+                {formatScore(item.value)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function HistoryCharts({
+  history,
+  percentile = "median",
+  initialProvider,
+}: {
+  history: HistoricalLeaderboardResult;
+  percentile?: PercentileType;
+  initialProvider?: string;
+}) {
+  const visibleDates = useMemo(
+    () =>
+      history.dates
+        .filter((date) => date >= HISTORY_START_DATE)
+        .slice(-HISTORY_DATE_CAP),
+    [history.dates]
+  );
+  const keys = PHASE_KEYS[percentile];
+
+  const providerOptions = useMemo(
+    () =>
+      history.providers
+        .map((provider) => ({
+          ...provider,
+          points: provider.points.filter((point) => visibleDates.includes(point.date)),
+        }))
+        .filter((provider) => provider.points.length > 0)
+        .sort((a, b) => {
+          const latestA = [...a.points].sort((x, y) => y.date.localeCompare(x.date))[0];
+          const latestB = [...b.points].sort((x, y) => y.date.localeCompare(x.date))[0];
+          const scoreA = latestA
+            ? computeValueScore({
+                latencyMs: latestA[keys.total] as number,
+                successRate: latestA.successRate,
+                pricePerHour: a.pricePerHour,
+              })
+            : -Infinity;
+          const scoreB = latestB
+            ? computeValueScore({
+                latencyMs: latestB[keys.total] as number,
+                successRate: latestB.successRate,
+                pricePerHour: b.pricePerHour,
+              })
+            : -Infinity;
+          if (scoreB !== scoreA) return scoreB - scoreA;
+          return a.displayName.localeCompare(b.displayName);
+        }),
+    [history.providers, keys.total, visibleDates]
+  );
+  const [selectedProvider, setSelectedProvider] = useState(
+    initialProvider && providerOptions.some((p) => p.provider === initialProvider)
+      ? initialProvider
+      : providerOptions[0]?.provider
+  );
+  const [displayedBreakdownProvider, setDisplayedBreakdownProvider] = useState(
+    selectedProvider
+  );
+  const [animatedBreakdownDomain, setAnimatedBreakdownDomain] =
+    useState<[number, number] | null>(null);
+  const animatedBreakdownDomainRef = useRef<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (providerOptions.length === 0) return;
+    if (selectedProvider && providerOptions.some((p) => p.provider === selectedProvider)) {
+      return;
+    }
+    setSelectedProvider(providerOptions[0]?.provider);
+  }, [providerOptions, selectedProvider]);
+
+  useEffect(() => {
+    if (!selectedProvider) return;
+    if (!displayedBreakdownProvider) {
+      setDisplayedBreakdownProvider(selectedProvider);
+      return;
+    }
+  }, [displayedBreakdownProvider, selectedProvider]);
+
+  const selectedSeries = providerOptions.find(
+    (p) => p.provider === selectedProvider
+  ) ?? providerOptions[0];
+  const displayedBreakdownSeries = providerOptions.find(
+    (p) => p.provider === displayedBreakdownProvider
+  ) ?? selectedSeries;
+
+  const providerConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    providerOptions.forEach((provider, index) => {
+      config[provider.provider] = {
+        label: provider.displayName,
+        color: PROVIDER_COLORS[index % PROVIDER_COLORS.length],
+      };
+    });
+    return config;
+  }, [providerOptions]);
+
+  const stackedData = useMemo(() => {
+    if (!displayedBreakdownSeries) return [];
+    return displayedBreakdownSeries.points.map((point) => ({
+      date: point.date,
+      label: formatDateLabel(point.date),
+      create: point[keys.create],
+      connect: point[keys.connect],
+      goto: point[keys.goto],
+      release: point[keys.release],
+    }));
+  }, [displayedBreakdownSeries, keys]);
+
+  const displayedBreakdownDomain = useMemo(
+    () => computeBreakdownDomain(displayedBreakdownSeries, keys),
+    [displayedBreakdownSeries, keys]
+  );
+
+  const targetBreakdownDomain = useMemo(
+    () => computeBreakdownDomain(selectedSeries, keys),
+    [keys, selectedSeries]
+  );
+
+  useEffect(() => {
+    const fromDomain = animatedBreakdownDomainRef.current ?? displayedBreakdownDomain;
+    const toDomain = targetBreakdownDomain;
+    const isScaleDown = toDomain[1] < fromDomain[1];
+
+    if (
+      selectedProvider === displayedBreakdownProvider &&
+      fromDomain[0] === toDomain[0] &&
+      fromDomain[1] === toDomain[1]
+    ) {
+      animatedBreakdownDomainRef.current = toDomain;
+      setAnimatedBreakdownDomain(toDomain);
+      return;
+    }
+
+    if (isScaleDown && selectedProvider !== displayedBreakdownProvider) {
+      setDisplayedBreakdownProvider(selectedProvider);
+    }
+
+    let frame = 0;
+    let timeout = 0;
+    const startedAt = performance.now();
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - startedAt) / BREAKDOWN_AXIS_LEAD_MS, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const nextDomain: [number, number] = [
+        fromDomain[0] + (toDomain[0] - fromDomain[0]) * eased,
+        fromDomain[1] + (toDomain[1] - fromDomain[1]) * eased,
+      ];
+      animatedBreakdownDomainRef.current = nextDomain;
+      setAnimatedBreakdownDomain(nextDomain);
+      if (progress < 1) {
+        frame = window.requestAnimationFrame(tick);
+      } else {
+        animatedBreakdownDomainRef.current = toDomain;
+        setAnimatedBreakdownDomain(toDomain);
+        if (!isScaleDown) {
+          timeout = window.setTimeout(() => {
+            setDisplayedBreakdownProvider(selectedProvider);
+          }, 40);
+        }
+      }
+    };
+
+    frame = window.requestAnimationFrame(tick);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+  }, [
+    displayedBreakdownDomain,
+    displayedBreakdownProvider,
+    selectedProvider,
+    targetBreakdownDomain,
+  ]);
+
+  const breakdownDomain = useMemo<[number, number]>(() => {
+    return animatedBreakdownDomain ?? displayedBreakdownDomain;
+  }, [animatedBreakdownDomain, displayedBreakdownDomain]);
+
+  const lineData = useMemo(() => {
+    return visibleDates.map((date) => {
+      const row: Record<string, string | number | null> = {
+        date,
+        label: formatDateLabel(date),
+      };
+      for (const provider of providerOptions) {
+        const point = provider.points.find((p) => p.date === date);
+        row[provider.provider] = point
+          ? computeValueScore({
+              latencyMs: point[keys.total] as number,
+              successRate: point.successRate,
+              pricePerHour: provider.pricePerHour,
+            })
+          : null;
+      }
+      return row;
+    });
+  }, [keys.total, providerOptions, visibleDates]);
+
+  const scoreDomain = useMemo<[number, number]>(() => {
+    const values = lineData.flatMap((row) =>
+      providerOptions
+        .map((provider) => row[provider.provider])
+        .filter((value): value is number => typeof value === "number")
+    );
+    if (values.length === 0) return [0, 1];
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    if (min === max) {
+      const pad = 0.02;
+      return [Math.max(0, min - pad), Math.min(1, max + pad)];
+    }
+
+    const pad = (max - min) * 0.08;
+    return [Math.max(0, min - pad), Math.min(1, max + pad)];
+  }, [lineData, providerOptions]);
+
+  if (providerOptions.length === 0) return null;
+
+  return (
+    <section id="history" className="reveal-up reveal-up-delay-1 mb-8 sm:mb-12 scroll-mt-20">
+      <div className="mb-3 sm:mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-xs uppercase tracking-widest text-muted-foreground font-semibold">
+            History
+          </h2>
+          <p className="mt-1 text-[0.72rem] sm:text-[0.78rem] text-muted-foreground">
+            Showing the latest {HISTORY_DATE_CAP} available run dates since May 15, 2026.
+          </p>
+        </div>
+        <div className="flex min-w-0 flex-wrap items-center justify-start gap-1.5 sm:justify-end">
+          {providerOptions.map((provider) => {
+            const active = provider.provider === selectedProvider;
+            return (
+              <button
+                key={provider.provider}
+                type="button"
+                onClick={() => setSelectedProvider(provider.provider)}
+                className={`shrink-0 rounded-[3px] border px-3 py-1.5 text-[0.68rem] font-medium transition-colors ${
+                  active
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-foreground/25 bg-background text-muted-foreground hover:border-foreground/50 hover:text-foreground"
+                }`}
+              >
+                {provider.displayName}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]">
+        <div className="border-[1.5px] border-foreground rounded-[3px] bg-background p-3 sm:p-4">
+          <div className="mb-3">
+            <h3 className="text-[0.72rem] font-semibold uppercase tracking-widest text-foreground">
+              Provider Value Score
+            </h3>
+            <p className="mt-1 text-[0.68rem] text-muted-foreground">
+              Composite score by run date. Higher is better.
+            </p>
+          </div>
+          <ChartContainer
+            config={providerConfig}
+            className="aspect-auto! h-[260px] w-full"
+          >
+            <LineChart data={lineData} margin={{ left: 0, right: 16, top: 8 }}>
+              <CartesianGrid vertical={false} strokeDasharray="2 2" />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={16}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={48}
+                domain={scoreDomain}
+                tickFormatter={(value) => Number(value).toFixed(2)}
+              />
+              <ChartTooltip
+                trigger="hover"
+                content={<ValueScoreTooltip config={providerConfig} />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              {providerOptions.map((provider) => (
+                <Line
+                  key={provider.provider}
+                  type="monotone"
+                  dataKey={provider.provider}
+                  stroke={`var(--color-${provider.provider})`}
+                  strokeWidth={2}
+                  dot={{ r: 2 }}
+                  activeDot={{ r: 4 }}
+                  connectNulls={false}
+                  isAnimationActive
+                  animationDuration={700}
+                  animationEasing="ease-out"
+                />
+              ))}
+            </LineChart>
+          </ChartContainer>
+        </div>
+
+        <div className="border-[1.5px] border-foreground rounded-[3px] bg-background p-3 sm:p-4">
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-[0.72rem] font-semibold uppercase tracking-widest text-foreground">
+                {selectedSeries?.displayName ?? "Provider"} Breakdown
+              </h3>
+              <p className="mt-1 text-[0.68rem] text-muted-foreground">
+                Stacked daily phase latency. Lower is better.
+              </p>
+            </div>
+          </div>
+          <ChartContainer
+            config={PHASE_CONFIG}
+            className="aspect-auto! h-[260px] w-full"
+          >
+            <BarChart data={stackedData} margin={{ left: 0, right: 8, top: 8 }}>
+              <CartesianGrid vertical={false} strokeDasharray="2 2" />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={16}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={48}
+                domain={breakdownDomain}
+                tickFormatter={(value) => `${(Number(value) / 1000).toFixed(1)}s`}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    className="rounded-none"
+                    labelFormatter={(_, payload) => payload?.[0]?.payload?.date}
+                    formatter={(value, name) => (
+                      <div className="flex w-full items-center justify-between gap-4">
+                        <span className="text-muted-foreground capitalize">{name}</span>
+                        <span className="font-mono text-foreground tabular-nums">
+                          {formatMs(value)}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              {(["create", "connect", "goto", "release"] as const).map((key, index, arr) => (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  stackId="latency"
+                  fill={`var(--color-${key})`}
+                  radius={index === arr.length - 1 ? [3, 3, 0, 0] : [0, 0, 0, 0]}
+                  isAnimationActive
+                  animationDuration={650}
+                  animationBegin={index * 70}
+                  animationEasing="ease-out"
+                />
+              ))}
+            </BarChart>
+          </ChartContainer>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/page-shell.tsx
+++ b/web/components/page-shell.tsx
@@ -30,6 +30,7 @@ export function PageShell({
           <NavBarActions>
             <nav className="hidden sm:flex items-center gap-8 text-sm font-medium">
               <a href="#leaderboard" className="text-muted-foreground hover:text-foreground transition-colors">Leaderboard</a>
+              <a href="#history" className="text-muted-foreground hover:text-foreground transition-colors">History</a>
               <a href="https://github.com/nottelabs/browserarena" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground transition-colors">Methodology</a>
               <a href="https://railway.com/deploy/UNedGj" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground transition-colors">Reproduce</a>
             </nav>

--- a/web/lib/data-shared.ts
+++ b/web/lib/data-shared.ts
@@ -79,6 +79,43 @@ export interface LeaderboardResult {
   metadata: LeaderboardMetadata;
 }
 
+export interface HistoricalProviderPoint {
+  date: string;
+  totalRuns: number;
+  successRate: number;
+  medianCreationMs: number;
+  medianConnectMs: number;
+  medianGotoMs: number;
+  medianScriptMs: number;
+  medianReleaseMs: number;
+  p90CreationMs: number;
+  p90ConnectMs: number;
+  p90GotoMs: number;
+  p90ScriptMs: number;
+  p90ReleaseMs: number;
+  p95CreationMs: number;
+  p95ConnectMs: number;
+  p95GotoMs: number;
+  p95ScriptMs: number;
+  p95ReleaseMs: number;
+  totalTimeMs: number;
+  p90TotalMs: number;
+  p95TotalMs: number;
+}
+
+export interface HistoricalProviderSeries {
+  provider: string;
+  displayName: string;
+  pricePerHour: number | null;
+  perSessionFee: number | null;
+  points: HistoricalProviderPoint[];
+}
+
+export interface HistoricalLeaderboardResult {
+  dates: string[];
+  providers: HistoricalProviderSeries[];
+}
+
 export interface ProviderCdpEndpointInfo {
   cdpHost: string;
   rttMs: number;

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -11,6 +11,9 @@ export type {
   VmMeta,
   LeaderboardMetadata,
   LeaderboardResult,
+  HistoricalLeaderboardResult,
+  HistoricalProviderPoint,
+  HistoricalProviderSeries,
   ProviderCdpEndpointInfo,
 } from "./data-shared";
 
@@ -25,6 +28,8 @@ import type {
   VmMeta,
   LeaderboardMetadata,
   LeaderboardResult,
+  HistoricalLeaderboardResult,
+  HistoricalProviderPoint,
 } from "./data-shared";
 
 const RESULTS_GITHUB_REPO =
@@ -477,6 +482,248 @@ function loadEntriesFromFs(
     providerMetaMap,
     providerRunDateMap,
   };
+}
+
+function readEntriesFromFsFile(filePath: string, runDate: string): BenchmarkEntry[] {
+  if (!fs.existsSync(filePath)) return [];
+  return parseJsonlLines(fs.readFileSync(filePath, "utf-8")).map((entry) => ({
+    ...entry,
+    _runDate: runDate,
+  }));
+}
+
+function summarizeHistoricalPoint(
+  entries: BenchmarkEntry[],
+  date: string
+): HistoricalProviderPoint | null {
+  if (entries.length === 0) return null;
+
+  const successful = entries.filter((e) => e.success);
+  const successRate = (successful.length / entries.length) * 100;
+
+  const creationTimes = successful.map((e) => e.session_creation_ms ?? 0);
+  const connectTimes = successful.map((e) => e.session_connect_ms ?? 0);
+  const gotoTimes = successful.map((e) => e.page_goto_ms ?? 0);
+  const scriptTimes = successful.map((e) => entryScriptMs(e) ?? 0);
+  const releaseTimes = successful.map((e) => e.session_release_ms ?? 0);
+
+  const medianCreationMs = median(creationTimes);
+  const medianConnectMs = median(connectTimes);
+  const medianGotoMs = median(gotoTimes);
+  const medianScriptMs = median(scriptTimes);
+  const medianReleaseMs = median(releaseTimes);
+
+  const p90CreationMs = percentile(creationTimes, 0.90);
+  const p90ConnectMs = percentile(connectTimes, 0.90);
+  const p90GotoMs = percentile(gotoTimes, 0.90);
+  const p90ScriptMs = percentile(scriptTimes, 0.90);
+  const p90ReleaseMs = percentile(releaseTimes, 0.90);
+
+  const p95CreationMs = percentile(creationTimes, 0.95);
+  const p95ConnectMs = percentile(connectTimes, 0.95);
+  const p95GotoMs = percentile(gotoTimes, 0.95);
+  const p95ScriptMs = percentile(scriptTimes, 0.95);
+  const p95ReleaseMs = percentile(releaseTimes, 0.95);
+
+  return {
+    date,
+    totalRuns: entries.length,
+    successRate,
+    medianCreationMs,
+    medianConnectMs,
+    medianGotoMs,
+    medianScriptMs,
+    medianReleaseMs,
+    p90CreationMs,
+    p90ConnectMs,
+    p90GotoMs,
+    p90ScriptMs,
+    p90ReleaseMs,
+    p95CreationMs,
+    p95ConnectMs,
+    p95GotoMs,
+    p95ScriptMs,
+    p95ReleaseMs,
+    totalTimeMs:
+      medianCreationMs +
+      medianConnectMs +
+      medianGotoMs +
+      medianScriptMs +
+      medianReleaseMs,
+    p90TotalMs:
+      p90CreationMs +
+      p90ConnectMs +
+      p90GotoMs +
+      p90ScriptMs +
+      p90ReleaseMs,
+    p95TotalMs:
+      p95CreationMs +
+      p95ConnectMs +
+      p95GotoMs +
+      p95ScriptMs +
+      p95ReleaseMs,
+  };
+}
+
+function loadHistoricalLeaderboardFromFs(
+  benchmark: "hello-browser",
+  concurrency?: number
+): HistoricalLeaderboardResult {
+  const resultsDir = getResultsDir();
+  const benchDir = path.join(resultsDir, benchmark);
+  if (!fs.existsSync(benchDir)) return { dates: [], providers: [] };
+
+  const EXCLUDED_PROVIDERS = new Set(["KERNEL_HEADFUL"]);
+  const effectiveConcurrency = concurrency ?? 1;
+  const dates = new Set<string>();
+  const providers = fs
+    .readdirSync(benchDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("_"));
+
+  const series = providers.flatMap((dir) => {
+    const providerPath = path.join(benchDir, dir.name);
+    const dateDirs = fs
+      .readdirSync(providerPath, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(e.name))
+      .map((e) => e.name)
+      .sort();
+
+    const points: HistoricalProviderPoint[] = [];
+    let providerName: string | undefined;
+
+    for (const date of dateDirs) {
+      const runDir = path.join(providerPath, date);
+      const concDir = path.join(runDir, `c${effectiveConcurrency}`);
+      const entries = fs.existsSync(concDir)
+        ? readEntriesFromFsFile(path.join(concDir, "results.jsonl"), date)
+        : effectiveConcurrency === 1
+          ? readEntriesFromFsFile(path.join(runDir, "results.jsonl"), date)
+          : [];
+      const filtered = entries.filter((entry) => !EXCLUDED_PROVIDERS.has(entry.provider));
+      if (filtered.length === 0) continue;
+
+      providerName = filtered[0]?.provider;
+      const point = summarizeHistoricalPoint(filtered, date);
+      if (!point) continue;
+      dates.add(date);
+      points.push(point);
+    }
+
+    if (!providerName || points.length === 0 || EXCLUDED_PROVIDERS.has(providerName)) {
+      return [];
+    }
+
+    const meta = PROVIDER_META[providerName] || {
+      displayName: providerName,
+      url: "#",
+    };
+
+    return [{
+      provider: providerName,
+      displayName: meta.displayName,
+      pricePerHour: getPricePerHour(providerName),
+      perSessionFee: getPerSessionFee(providerName),
+      points,
+    }];
+  });
+
+  series.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+  return {
+    dates: [...dates].sort(),
+    providers: series,
+  };
+}
+
+async function loadHistoricalLeaderboardFromGitHub(
+  benchmark: "hello-browser",
+  concurrency?: number
+): Promise<HistoricalLeaderboardResult> {
+  const basePath = `results/${benchmark}`;
+  const effectiveConcurrency = concurrency ?? 1;
+  const EXCLUDED_PROVIDERS = new Set(["KERNEL_HEADFUL"]);
+  const dates = new Set<string>();
+  const series: HistoricalLeaderboardResult["providers"] = [];
+
+  const providerDirs = await listFromGitHub(basePath);
+  const dirs = providerDirs.filter(
+    (e) => e.type === "dir" && !e.name.startsWith("_")
+  );
+
+  for (const dir of dirs) {
+    const dateDirs = await listFromGitHub(`${basePath}/${dir.name}`);
+    const runDates = dateDirs
+      .filter((e) => e.type === "dir" && /^\d{4}-\d{2}-\d{2}$/.test(e.name))
+      .map((e) => e.name)
+      .sort();
+
+    const points: HistoricalProviderPoint[] = [];
+    let providerName: string | undefined;
+
+    for (const date of runDates) {
+      const runPath = `${basePath}/${dir.name}/${date}`;
+      const contents = await listFromGitHub(runPath);
+      const hasConcurrencyDirs = contents.some(
+        (e) => e.type === "dir" && /^c\d+$/.test(e.name)
+      );
+      const resultPath = hasConcurrencyDirs
+        ? `${runPath}/c${effectiveConcurrency}/results.jsonl`
+        : effectiveConcurrency === 1
+          ? `${runPath}/results.jsonl`
+          : null;
+      if (!resultPath) continue;
+
+      try {
+        const entries = parseJsonlLines(await fetchFromGitHub(resultPath)).map(
+          (entry) => ({ ...entry, _runDate: date })
+        );
+        const filtered = entries.filter((entry) => !EXCLUDED_PROVIDERS.has(entry.provider));
+        if (filtered.length === 0) continue;
+
+        providerName = filtered[0]?.provider;
+        const point = summarizeHistoricalPoint(filtered, date);
+        if (!point) continue;
+        dates.add(date);
+        points.push(point);
+      } catch {
+        // skip missing concurrency levels and malformed runs
+      }
+    }
+
+    if (!providerName || points.length === 0 || EXCLUDED_PROVIDERS.has(providerName)) {
+      continue;
+    }
+
+    const meta = PROVIDER_META[providerName] || {
+      displayName: providerName,
+      url: "#",
+    };
+    series.push({
+      provider: providerName,
+      displayName: meta.displayName,
+      pricePerHour: getPricePerHour(providerName),
+      perSessionFee: getPerSessionFee(providerName),
+      points,
+    });
+  }
+
+  series.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+  return {
+    dates: [...dates].sort(),
+    providers: series,
+  };
+}
+
+export async function loadHistoricalLeaderboard(
+  benchmark: "hello-browser" = "hello-browser",
+  concurrency?: number
+): Promise<HistoricalLeaderboardResult> {
+  const resultsDir = getResultsDir();
+  if (fs.existsSync(resultsDir)) {
+    return loadHistoricalLeaderboardFromFs(benchmark, concurrency);
+  }
+  return loadHistoricalLeaderboardFromGitHub(benchmark, concurrency);
 }
 
 function listBenchmarkDatesFromFs(benchmark: "v0"): string[] {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3824,9 +3824,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6736,7 +6736,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- add historical aggregation for hello-browser benchmark runs
- render value score trends across providers with a rolling latest-week window
- add selectable provider latency breakdown with staged y-axis transitions

## Test
- npm run build