### PR TITLE
Run Browser Use sessions proxyless on the v3 API

### DIFF
--- a/src/providers/browser-use.ts
+++ b/src/providers/browser-use.ts
@@ -12,13 +12,14 @@ export class BrowserUseProvider implements ProviderClient {
 
   async create(): Promise<ProviderSession> {
     const apiKey = requireEnv("BROWSER_USE_API_KEY");
-    const res = await fetch("https://api.browser-use.com/api/v2/browsers", {
+    const res = await fetch("https://api.browser-use.com/api/v3/browsers", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-Browser-Use-API-Key": apiKey,
       },
-      body: JSON.stringify({}),
+      // proxyCountryCode: null runs the session proxyless (the API defaults to "us").
+      body: JSON.stringify({ proxyCountryCode: null }),
       signal: AbortSignal.timeout(90_000),
     });
     if (!res.ok) {
@@ -34,7 +35,7 @@ export class BrowserUseProvider implements ProviderClient {
 
   async release(id: string): Promise<void> {
     const apiKey = requireEnv("BROWSER_USE_API_KEY");
-    const res = await fetch(`https://api.browser-use.com/api/v2/browsers/${id}`, {
+    const res = await fetch(`https://api.browser-use.com/api/v3/browsers/${id}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -55,7 +56,7 @@ export class BrowserUseProvider implements ProviderClient {
     const delayMs = 3000;
 
     for (let i = 0; i < maxAttempts; i++) {
-      const res = await fetch(`https://api.browser-use.com/api/v2/sessions/${sessionId}`, {
+      const res = await fetch(`https://api.browser-use.com/api/v3/sessions/${sessionId}`, {
         headers: { "X-Browser-Use-API-Key": apiKey },
         signal: AbortSignal.timeout(30_000),
       });

--- a/src/providers/browser-use.ts
+++ b/src/providers/browser-use.ts
@@ -18,7 +18,7 @@ export class BrowserUseProvider implements ProviderClient {
         "Content-Type": "application/json",
         "X-Browser-Use-API-Key": apiKey,
       },
-      body: JSON.stringify({ proxyCountryCode: null }), // null runs the session proxyless (the API defaults to "us").
+      body: JSON.stringify({ proxyCountryCode: null }),
       signal: AbortSignal.timeout(90_000),
     });
     if (!res.ok) {

--- a/src/providers/browser-use.ts
+++ b/src/providers/browser-use.ts
@@ -18,8 +18,7 @@ export class BrowserUseProvider implements ProviderClient {
         "Content-Type": "application/json",
         "X-Browser-Use-API-Key": apiKey,
       },
-      // proxyCountryCode: null runs the session proxyless (the API defaults to "us").
-      body: JSON.stringify({ proxyCountryCode: null }),
+      body: JSON.stringify({ proxyCountryCode: null }), // null runs the session proxyless (the API defaults to "us").
       signal: AbortSignal.timeout(90_000),
     });
     if (!res.ok) {


### PR DESCRIPTION
## What

Switch the Browser Use provider from the v2 to the v3 API and run sessions proxyless.

- `create`: POST `https://api.browser-use.com/api/v3/browsers`, now sending `proxyCountryCode: null` (was an empty body `{}`) so sessions run without an upstream proxy. The v3 API defaults `proxyCountryCode` to `"us"`, so an explicit `null` is required to go proxyless — per the [v3 create-browser-session docs](https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session).
- `release`: same `PATCH .../browsers/{id}` with body `{ "action": "stop" }`, only the URL moved from v2 to v3.
- `downloadRecording`: session lookup URL moved from v2 to v3 (`GET .../sessions/{id}`).

No other behavior changed.