### PR TITLE
browser-use provider: new infra (wss CDP + $0.02/hr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All providers tested from the same EC2 instances. TCP+TLS round-trip times measu
 | Hyperbrowser | `connect-us-east-1.hyperbrowser.ai` | 9 ms | us-east-1 |
 | Steel | `connect.steel.dev` | 14 ms | us-east-1 |
 | Kernel | `api.onkernel.com` | 14 ms | us-east-1 |
-| Browser Use | `cdp1.browser-use.com` | 29 ms | us-east-1 |
+| Browser Use | `cdp.browser-use.com` | 29 ms | us-east-1 |
 | Anchor Browser | `connect.anchorbrowser.io` | 38 ms | us-east-1 |
 | Browserbase | `connect.usw2.browserbase.com` | 62 ms | us-west-1 |
 

--- a/src/providers/browser-use.ts
+++ b/src/providers/browser-use.ts
@@ -5,7 +5,7 @@ export class BrowserUseProvider implements ProviderClient {
   readonly name = "BROWSER_USE";
 
   computeCost(seconds: number): number {
-    const perHour = 0.06;
+    const perHour = 0.02;
     const billedSeconds = Math.max(60, Math.ceil(seconds / 60) * 60);
     return Math.round((billedSeconds / 3600) * perHour * 1e8) / 1e8;
   }
@@ -29,7 +29,7 @@ export class BrowserUseProvider implements ProviderClient {
     const id = data.id;
     const cdpUrl = data.cdpUrl;
     if (!id || !cdpUrl) throw new Error("Invalid Browser Use response: missing id or cdpUrl");
-    return { id, cdpUrl };
+    return { id, cdpUrl: cdpUrl.replace("https://", "wss://") };
   }
 
   async release(id: string): Promise<void> {

--- a/web/lib/data-shared.ts
+++ b/web/lib/data-shared.ts
@@ -135,7 +135,7 @@ export const PROVIDER_CDP_ENDPOINT: Record<string, ProviderCdpEndpointInfo> = {
   KERNEL: { cdpHost: "api.onkernel.com", rttMs: 14, proxied: false },
   ANCHORBROWSER: { cdpHost: "connect.anchorbrowser.io", rttMs: 38, proxied: false },
   HYPERBROWSER: { cdpHost: "connect-us-east-1.hyperbrowser.ai", rttMs: 9, proxied: false },
-  BROWSER_USE: { cdpHost: "cdp1.browser-use.com", rttMs: 29, proxied: false },
+  BROWSER_USE: { cdpHost: "cdp.browser-use.com", rttMs: 29, proxied: false },
 };
 
 /** Benchmark runner VM (`_meta.json`): cloud + region when present. */

--- a/web/lib/pricing.ts
+++ b/web/lib/pricing.ts
@@ -27,7 +27,7 @@ const PRICING: Record<string, { unit: UnitPricing }> = {
     unit: { ratePerHour: 0.06, billing: "per_second", minimumSeconds: 0, perSessionCreationFee: 0 },
   },
   BROWSER_USE: {
-    unit: { ratePerHour: 0.06, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },
+    unit: { ratePerHour: 0.02, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },
   },
 };
 


### PR DESCRIPTION
Switches the `browser-use` provider to the new browser infrastructure:

- **CDP over `wss://`** — `src/providers/browser-use.ts` rewrites the returned `cdpUrl` from `https://` to `wss://` (the edge now routes root `wss://` upgrades straight to the browser CDP endpoint, cutting connect latency).
- **Cost `$0.06 → $0.02/hr`** — updated `perHour` to reflect the new infra pricing.
- **README** — latency-table host `cdp1.browser-use.com → cdp.browser-use.com` (the API already returns the new host).