### PR TITLE
[NOT-490] Move Browserbase benchmark from us-west to us-east

### DIFF
--- a/scripts/run-and-publish.sh
+++ b/scripts/run-and-publish.sh
@@ -31,8 +31,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$REGION" in
-  us-east) PROVIDERS="steel,kernel,kernel-headful,hyperbrowser,anchorbrowser,browser-use" ;;
-  us-west) PROVIDERS="notte,browserbase" ;;
+  us-east) PROVIDERS="steel,kernel,kernel-headful,hyperbrowser,anchorbrowser,browser-use,browserbase" ;;
+  us-west) PROVIDERS="notte" ;;
   "")      echo "[ERROR] --region us-east|us-west required" >&2; exit 2 ;;
   *)       echo "[ERROR] invalid --region: $REGION (want us-east or us-west)" >&2; exit 2 ;;
 esac

--- a/src/providers/browserbase.ts
+++ b/src/providers/browserbase.ts
@@ -22,7 +22,7 @@ export class BrowserbaseProvider implements ProviderClient {
 
   async create(): Promise<ProviderSession> {
     const projectId = requireEnv("BROWSERBASE_PROJECT_ID");
-    const session = await (await this.client()).sessions.create({ projectId, region: "us-west-2" });
+    const session = await (await this.client()).sessions.create({ projectId, region: "us-east-1" });
     const id = session?.id;
     const cdpUrl = session?.connectUrl;
     if (!id || !cdpUrl) throw new Error("Invalid Browserbase session response");


### PR DESCRIPTION
## What

Move the Browserbase benchmark from the **us-west** runner to the **us-east** runner so its session and runner are co-located in East, matching every other provider.

- `src/providers/browserbase.ts`: session region `us-west-2` → `us-east-1`
- `scripts/run-and-publish.sh`: move `browserbase` from the `us-west` provider list to `us-east`; Notte stays on the west box

Linear: NOT-490 https://linear.app/nottelabsinc/issue/NOT-490/browserarena-pr-17-move-browserbase-benchmark-from-us-west-to-us-east