### PR TITLE
chore(web): skip preview builds when no web files change

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ../web ../results"
+}


### PR DESCRIPTION
The site is deployed from the `web` directory, but every commit to the repository currently triggers a build, including ones that only touch the benchmark runner, the workflows or the docs. On pull requests that never touch the site this shows up as an unnecessary deployment and, for pull requests from forks, as a failing authorization check on a build that was not needed in the first place.

This adds an ignore command so a build only runs when it could actually change the output.

```json
{
  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ../web ../results"
}
```

`results` is included on purpose and should stay. The site reads the benchmark data from outside its own directory, at `web/lib/data.ts`:

```js
return path.join(process.cwd(), "..", "results");
```

so the scheduled runs that commit new results have to keep triggering a deployment. Without that path in the rule the published leaderboard would quietly stop updating, which is also why the rule cannot simply be "only build when `web` changes".

Checked against real commits in this repository, where the command exits 0 to skip a build and 1 to run one:

| Commit | Touches | Result |
| --- | --- | --- |
| `f8b9998` | `web`, `package.json`, `.github` | build |
| `9f40712` | `results` | build |
| `7fd9ba4` | `results` | build |
| `23ab3db` | `src` | skipped |
| `6abad17` | `.github` | skipped |

Based on the last 15 deployments, the scheduled result commits keep deploying as they do today, and the builds that get skipped are the ones that could not have affected the site.