### PR TITLE
feat(web): rework value score presets

### DIFF
--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -131,9 +131,9 @@ function computeValueScores(
 }
 
 const WEIGHT_PRESETS: { label: string; weights: { latency: number; reliability: number; cost: number } }[] = [
-  { label: "Reliable first", weights: { latency: 20, reliability: 60, cost: 20 } },
-  { label: "Speed first", weights: { latency: 60, reliability: 20, cost: 20 } },
-  { label: "Budget first", weights: { latency: 20, reliability: 20, cost: 60 } },
+  { label: "Fastest", weights: { latency: 100, reliability: 0, cost: 0 } },
+  { label: "Cheapest", weights: { latency: 0, reliability: 0, cost: 100 } },
+  { label: "Most reliable", weights: { latency: 5, reliability: 90, cost: 5 } },
   { label: "Balanced", weights: { latency: 33, reliability: 33, cost: 33 } },
 ];
 


### PR DESCRIPTION
Reworks the Value Score presets so each one expresses a single clear question a visitor might have, rather than a soft tilt toward one dimension.

Before, each preset put 60 percent on its own dimension and 20 percent on the other two, which meant "Speed first" was still substantially a cost and reliability ranking.

| Preset | Reliability | Latency | Cost |
| --- | --- | --- | --- |
| Fastest | 0 | 100 | 0 |
| Cheapest | 0 | 0 | 100 |
| Most reliable | 90 | 5 | 5 |
| Balanced | 33 | 33 | 33 |

Weights are normalised in both the score calculation and the bar, so these are ratios rather than absolute values, and `Balanced` is unchanged.

## Why "Most reliable" is 90/5/5 rather than 100/0/0

Every provider currently records a 100 percent success rate. At a pure 100/0/0 reliability weight they all score exactly 1.000, which produces a seven way tie. The table breaks ties with `Math.random()`, recomputed whenever the sort input changes, so the ranking is not just uninformative but reshuffles on each click. Selecting the preset five times in a browser gave five different orderings, all showing 1.000.

Giving latency and cost 5 percent each keeps reliability clearly dominant while letting the other two dimensions separate providers that are tied on it. Verified in a browser: the ordering is now stable across repeated selections and the scores are distinct.

`Fastest` and `Cheapest` do not have this problem to the same degree, since latency and price already differ between providers, and they are left at a pure single dimension weight.

## Known remaining tie

`Cheapest` still ties two providers that are on the same hourly price, and those two swap position between clicks for the same `Math.random()` reason. It is cosmetic and limited to adjacent rows, but it is the same underlying behaviour. Making the tiebreaker deterministic would resolve it for every preset at once, and is deliberately left out of this change.

## Verification

Built and served locally, then exercised each preset in a browser:

- Buttons render in order and the weight bar reports the expected split for each.
- `Fastest`, `Cheapest` and `Balanced` produce the same orderings as the equivalent weights before this change.
- `Most reliable` returns a single stable ordering across repeated selection, where a pure reliability weight returned a different one each time.