### PR TITLE
Update notte browser rates 

### DIFF
--- a/src/providers/notte.ts
+++ b/src/providers/notte.ts
@@ -23,7 +23,7 @@ export class NotteProvider implements ProviderClient {
   private baseUrl: string;
 
   computeCost(seconds: number): number {
-    const perHour = 0.05;
+    const perHour = 0;
     const billedSeconds = Math.max(60, Math.ceil(seconds / 60) * 60);
     return Math.round((billedSeconds / 3600) * perHour * 1e8) / 1e8;
   }

--- a/web/lib/pricing.ts
+++ b/web/lib/pricing.ts
@@ -9,7 +9,7 @@ interface UnitPricing {
 
 const PRICING: Record<string, { unit: UnitPricing }> = {
   NOTTE: {
-    unit: { ratePerHour: 0.05, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },
+    unit: { ratePerHour: 0, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },
   },
   STEEL: {
     unit: { ratePerHour: 0.1, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },


### PR DESCRIPTION
Notte's browser runtime rate changes to $0/hour. This updates the two places the rate is defined:

- `web/lib/pricing.ts` - `NOTTE.unit.ratePerHour`
- `src/providers/notte.ts` - `computeCost`

Other providers' rates are unchanged. Leaderboard cost and Value Score figures will reflect this on the next benchmark run.

Draft until the rate is live.