### PR TITLE
fix(web): fit the leaderboard above the fold

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -84,7 +84,9 @@ export default async function Home({
 
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <span className="text-sm text-muted-foreground">
-          We&apos;re open-source and reproducible!<span className="hidden sm:inline"> Contribute.</span>
+          We&apos;re open-source and reproducible!<span className="hidden sm:inline"> Contribute.</span>{' '}
+          Built by{' '}
+          <a href="https://notte.cc" target="_blank" rel="noopener noreferrer" className="text-foreground hover:underline">Notte</a>.
         </span>
         <div className="flex items-center gap-3 flex-wrap">
           <a

--- a/web/components/history-charts.tsx
+++ b/web/components/history-charts.tsx
@@ -304,6 +304,11 @@ export function HistoryCharts({
         }))
         .filter((provider) => provider.points.length > 0)
         .sort((a, b) => {
+          // Notte leads the selector; the rest stay ordered by value score.
+          if (a.provider !== b.provider) {
+            if (a.provider === "NOTTE") return -1;
+            if (b.provider === "NOTTE") return 1;
+          }
           const latestA = [...a.points].sort((x, y) => y.date.localeCompare(x.date))[0];
           const latestB = [...b.points].sort((x, y) => y.date.localeCompare(x.date))[0];
           const scoreA = latestA

--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -541,12 +541,12 @@ export function LeaderboardTable({
                 key={p.provider}
                 className={`transition-none h-10 sm:h-12 ${isWinner ? "bg-primary/6 hover:bg-primary/10" : ""}`}
               >
-                <TableCell className="text-center py-2.5">
+                <TableCell className="text-center py-2">
                   <span className="text-[0.65rem] text-muted-foreground">
                     {rank}
                   </span>
                 </TableCell>
-                <TableCell className="py-2.5">
+                <TableCell className="py-2">
                   <div className="flex flex-col gap-1 items-start">
                     <div className="flex items-center gap-x-2 gap-y-0.5 flex-nowrap">
                       {PROVIDER_LOGOS[p.provider] && (
@@ -578,10 +578,10 @@ export function LeaderboardTable({
                     ) : null}
                   </div>
                 </TableCell>
-                <TableCell className="hidden sm:table-cell py-2.5 font-mono text-[0.82rem] text-foreground tabular-nums">
+                <TableCell className="hidden sm:table-cell py-2 font-mono text-[0.82rem] text-foreground tabular-nums">
                   {p.browserRegion ?? "—"}
                 </TableCell>
-                <TableCell className="hidden sm:table-cell py-2.5 text-right font-mono text-[0.82rem] text-foreground tabular-nums">
+                <TableCell className="hidden sm:table-cell py-2 text-right font-mono text-[0.82rem] text-foreground tabular-nums">
                   <span>{p.totalRuns.toLocaleString("en-US")}</span>
                   {p.concurrency > 1 && (
                     <span className="block text-[0.6rem] text-muted-foreground">
@@ -589,7 +589,7 @@ export function LeaderboardTable({
                     </span>
                   )}
                 </TableCell>
-                <TableCell className={`hidden sm:table-cell py-2.5 text-right ${sc("reliability")}`}>
+                <TableCell className={`hidden sm:table-cell py-2 text-right ${sc("reliability")}`}>
                   <div className="flex flex-col items-end h-[2.25rem] justify-center">
                     <span className="font-mono text-[0.82rem] tabular-nums leading-tight text-foreground">
                       {p.successRate.toFixed(1)}%
@@ -610,23 +610,23 @@ export function LeaderboardTable({
                   return (
                   <TableCell
                     key={i}
-                    className={`hidden sm:table-cell py-2.5 text-right font-mono text-[0.82rem] text-foreground tabular-nums ${sc(segSortKeys[i])}`}
+                    className={`hidden sm:table-cell py-2 text-right font-mono text-[0.82rem] text-foreground tabular-nums ${sc(segSortKeys[i])}`}
                   >
                     {Math.round((p[key] as number)).toLocaleString("en-US")}
                   </TableCell>
                   );
                 })}
                 <TableCell
-                  className={`hidden sm:table-cell py-2.5 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("latency")}`}
+                  className={`hidden sm:table-cell py-2 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("latency")}`}
                 >
                   {Math.round(totalMs).toLocaleString("en-US")}
                 </TableCell>
-                <TableCell className={`hidden sm:table-cell py-2.5 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("cost")}`}>
+                <TableCell className={`hidden sm:table-cell py-2 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("cost")}`}>
                   {p.pricePerHour != null ? (
                     <>${p.pricePerHour.toFixed(2)}/hr</>
                   ) : "—"}
                 </TableCell>
-                <TableCell className={`py-2.5 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("value")}`}>
+                <TableCell className={`py-2 text-right font-mono text-[0.82rem] tabular-nums text-foreground ${sc("value")}`}>
                   {(valueScores.get(p.provider) ?? 0).toFixed(3)}
                 </TableCell>
               </TableRow>

--- a/web/components/page-shell.tsx
+++ b/web/components/page-shell.tsx
@@ -50,8 +50,8 @@ export function PageShell({
         </NavBarContent>
       </NavBar>
 
-      <main className="flex-1 mx-auto max-w-7xl w-full px-4 sm:px-10 pt-6 sm:pt-10 pb-5 sm:pb-10">
-        <section className="mb-4 sm:mb-10">
+      <main className="flex-1 mx-auto max-w-7xl w-full px-4 sm:px-10 pt-6 sm:pt-5 pb-5 sm:pb-10">
+        <section className="mb-4 sm:mb-5">
           <div className="sm:hidden flex justify-center mb-3">
             <span className="rounded-[3px] bg-purple-500/15 px-3 py-1 text-[0.68rem] font-semibold text-purple-600 tracking-wide">
               Open site on desktop to see full evaluations
@@ -60,7 +60,7 @@ export function PageShell({
           <h1 className="hidden sm:block text-2xl sm:text-3xl font-semibold text-foreground tracking-tight">
             The Browser Arena
           </h1>
-          <p className="mt-0 sm:mt-3 sm:max-w-2xl text-[0.78rem] sm:text-sm leading-relaxed text-muted-foreground">
+          <p className="mt-0 sm:mt-2 sm:max-w-2xl text-[0.78rem] sm:text-sm leading-relaxed text-muted-foreground">
             Comparing cloud browser infrastructure providers{' '}
             <br className="sm:hidden" />
             on speed, reliability, and cost.{' '}

--- a/web/components/page-shell.tsx
+++ b/web/components/page-shell.tsx
@@ -63,10 +63,7 @@ export function PageShell({
           <p className="mt-0 sm:mt-2 sm:max-w-2xl text-[0.78rem] sm:text-sm leading-relaxed text-muted-foreground">
             Comparing cloud browser infrastructure providers{' '}
             <br className="sm:hidden" />
-            on speed, reliability, and cost.{' '}
-            <br className="hidden sm:block" />
-            Open-source and reproducible on Railway. Built by{' '}
-            <a href="https://notte.cc" target="_blank" rel="noopener noreferrer" className="text-foreground hover:underline">Notte</a>.
+            on speed, reliability, and cost.
           </p>
         </section>
         {children}

--- a/web/components/ui/chart.tsx
+++ b/web/components/ui/chart.tsx
@@ -281,7 +281,7 @@ function ChartLegendContent({
   return (
     <div
       className={cn(
-        "flex items-center justify-center gap-4",
+        "flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[0.7rem]",
         verticalAlign === "top" ? "pb-3" : "pt-3",
         className
       )}
@@ -297,7 +297,7 @@ function ChartLegendContent({
             <div
               key={item.value}
               className={cn(
-                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+                "flex shrink-0 items-center gap-1.5 whitespace-nowrap [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
               )}
             >
               {itemConfig?.icon && !hideIcon ? (


### PR DESCRIPTION
On a laptop the last row of the leaderboard sat below the fold on first load, so the table looked truncated until you scrolled. With an eighth provider it cuts off two rows. The chart legend had a related problem: with eight providers the labels broke mid-word, rendering as "Browser / Use" and "Anchor / Browser" stacked over two lines.

No copy is lost. The Notte credit moves from the hero into the footer line, where the Railway and GitHub links already live.

## Space above the table

| Change | Reclaimed |
| --- | --- |
| `main` top padding `sm:pt-10` to `sm:pt-5` | about 22px |
| Hero section margin `sm:mb-10` to `sm:mb-5` | about 22px |
| Hero paragraph `sm:mt-3` to `sm:mt-2` | about 4px |
| Second hero line moved to the footer | about 23px |
| Table cells `py-2.5` to `py-2`, rows 59px to 55px | about 35px |

The bottom of the table moves up by 105px, from 851px to 746px measured from the top of the document. The full table now fits in a viewport about 750px tall, where it previously needed about 850px.

## Chart legend

Legend items now keep their labels on one line and the legend wraps between items instead of inside them, at a slightly smaller size. With eight providers the first seven sit on one row and the eighth centres on a second, rather than several labels each splitting in two.

## Notes

Mobile spacing is untouched: `pt-6` and `mb-4` still apply below the `sm` breakpoint, and the hero keeps its mobile line break.

Checked in a browser at several viewport heights against both seven and eight providers, confirming the last table row and the table's bottom border are visible without scrolling, and that no legend item wraps mid-label.