### PR TITLE
feat(web): add Tilion pricing

### DIFF
--- a/web/lib/pricing.ts
+++ b/web/lib/pricing.ts
@@ -29,6 +29,9 @@ const PRICING: Record<string, { unit: UnitPricing }> = {
   BROWSER_USE: {
     unit: { ratePerHour: 0.02, billing: "per_minute", minimumSeconds: 60, perSessionCreationFee: 0 },
   },
+  TILION: {
+    unit: { ratePerHour: 0.03, billing: "per_second", minimumSeconds: 0, perSessionCreationFee: 0 },
+  },
 };
 
 function computeUnitCost(pricing: UnitPricing, durationSeconds: number): number {


### PR DESCRIPTION
Adds the missing `PRICING` entry for Tilion, which is registered as a provider but has no rate defined.

```ts
TILION: {
  unit: { ratePerHour: 0.03, billing: "per_second", minimumSeconds: 0, perSessionCreationFee: 0 },
},
```

## Why this is needed before the next run

`getPricePerHour` returns `null` for any provider missing from the map, and a null price is not treated as neutral by the Value Score. In `computeValueScores` the cost term becomes

```ts
const normCost = cost != null && costRange > 0 ? clamp01(...) : 0;
```

so a provider without a rate scores zero on cost rather than being excluded from that dimension. Tilion would therefore rank last on cost, and last on the Cheapest preset, despite being one of the cheaper providers on the board. The COST/HR column would also render empty.

## The numbers

The rate is the provider's stated list rate for the configuration being benchmarked, and matches `computeCost` in `src/providers/tilion.ts` so the leaderboard column and the runner agree. Verified across a range of session durations, where both produce identical figures:

| Duration | Web | Runner |
| --- | --- | --- |
| 30s | $0.00025000 | $0.00025000 |
| 60s | $0.00050000 | $0.00050000 |
| 3600s | $0.03000000 | $0.03000000 |

`per_second` billing with no minimum and no creation fee mirrors the provider's own cost function, which divides elapsed seconds by 3600 with no rounding. This is the same shape already used for Hyperbrowser and Kernel; the remaining providers bill per minute with a 60 second floor.

Worth recording for provenance: Tilion publishes plan based pricing rather than an on-demand hourly rate, so this figure is supplied by the provider rather than read off a public rate card. It is worth confirming with them before it has been on the leaderboard for long, and revisiting if they publish an hourly rate later.

Build and audit pass in `web`.