### PR TITLE
chore: disable proxies for notte sessions

### DIFF
--- a/src/providers/notte.ts
+++ b/src/providers/notte.ts
@@ -46,7 +46,7 @@ export class NotteProvider implements ProviderClient {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${this.getApiKey()}`,
       },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ proxies: false }),
     });
 
     if (!startResponse.ok) {


### PR DESCRIPTION
Start Notte sessions with `proxies: false` so the benchmark measures the raw browser session without proxy routing.

This matches how the other providers are configured:
- `tilion` → `residential: false`
- `browser-use` → `proxyCountryCode: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)