### PR TITLE
ci: schedule the daily benchmark from GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,242 @@
+name: Benchmark
+
+# Drives the daily benchmark on the two EC2 boxes. GitHub is only the
+# scheduler and the log viewer: the run itself, the provider API keys, and the
+# push to main all still happen on the instance via scripts/run-and-publish.sh.
+#
+# Transport is AWS SSM Send-Command over GitHub OIDC, so there are no inbound
+# ports on the boxes and no long-lived AWS or SSH credentials in this repo.
+#
+# Setup (once per box), see README "Automated runs":
+#   - SSM agent running, instance profile with AmazonSSMManagedInstanceCore
+#   - repo cloned at /home/ubuntu/browserarena with .env and a write deploy key
+#   - the old crontab entry removed, so this workflow is the only scheduler
+#
+# Repo secrets: AWS_ROLE_ARN, US_EAST_1_INSTANCE_ID, US_WEST_1_INSTANCE_ID
+
+on:
+  schedule:
+    # Same times the box crontabs used. us-east runs longer (8 providers), so
+    # us-west is staggered an hour to keep the two `git push`es apart.
+    - cron: "0 3 * * *" # us-east-1
+    - cron: "0 4 * * *" # us-west-1
+  workflow_dispatch:
+    inputs:
+      region:
+        description: Which box(es) to run on
+        type: choice
+        required: true
+        default: both
+        options: [both, us-east-1, us-west-1]
+      provider:
+        description: Provider to run (all = every provider owned by the region)
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - notte
+          - browserbase
+          - steel
+          - kernel
+          - kernel-headful
+          - hyperbrowser
+          - anchorbrowser
+          - browser-use
+          - tilion
+      runs:
+        description: Measured sessions per concurrency level
+        type: string
+        required: false
+        default: "100"
+      dry_run:
+        description: Run the benchmark but skip the commit/push
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  id-token: write # required for the OIDC role assumption
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Resolve region/provider into a matrix
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          INPUT_REGION: ${{ inputs.region }}
+          INPUT_PROVIDER: ${{ inputs.provider }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            # Each cron line owns one region, mirroring the old per-box crontabs.
+            case "$SCHEDULE" in
+              "0 3 * * *") REGION="us-east-1" ;;
+              "0 4 * * *") REGION="us-west-1" ;;
+              *) echo "::error::unmapped schedule '$SCHEDULE'"; exit 1 ;;
+            esac
+            PROVIDER="all"
+          else
+            REGION="$INPUT_REGION"
+            PROVIDER="$INPUT_PROVIDER"
+          fi
+
+          # `owns` mirrors the region->provider map in scripts/run-and-publish.sh.
+          # Keep the two in sync; the script re-validates and fails fast if not.
+          east='{"aws_region":"us-east-1","script_region":"us-east","instance_secret":"US_EAST_1_INSTANCE_ID","owns":"steel,kernel,kernel-headful,hyperbrowser,anchorbrowser,browser-use,browserbase,tilion"}'
+          west='{"aws_region":"us-west-1","script_region":"us-west","instance_secret":"US_WEST_1_INSTANCE_ID","owns":"notte"}'
+
+          # region=both + a single provider narrows to whichever box owns it,
+          # rather than dispatching a guaranteed failure to the other one.
+          matrix=$(jq -cn \
+            --argjson east "$east" --argjson west "$west" \
+            --arg region "$REGION" --arg provider "$PROVIDER" '
+              [$east, $west]
+              | map(select($region == "both" or .aws_region == $region))
+              | map(select($provider == "all"
+                  or ((","+.owns+",") | contains(","+$provider+","))))
+              | map({
+                  aws_region, script_region, instance_secret,
+                  providers: (if $provider == "all" then .owns else $provider end)
+                })
+            ')
+
+          if [[ "$(jq 'length' <<<"$matrix")" -eq 0 ]]; then
+            echo "::error::no box runs provider '$PROVIDER' in region '$REGION'"
+            exit 1
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          jq . <<<"$matrix"
+
+  bench:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    # One run per box at a time. Not cancel-in-progress: a queued dispatch
+    # should wait for the in-flight benchmark rather than kill it.
+    concurrency:
+      group: benchmark-${{ matrix.target.script_region }}
+      cancel-in-progress: false
+    steps:
+      - name: Assume AWS role via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ matrix.target.aws_region }}
+          role-session-name: browserarena-${{ matrix.target.script_region }}
+
+      - name: Send benchmark command
+        id: send
+        env:
+          INSTANCE_ID: ${{ secrets[matrix.target.instance_secret] }}
+          SCRIPT_REGION: ${{ matrix.target.script_region }}
+          PROVIDERS: ${{ matrix.target.providers }}
+          RUNS: ${{ inputs.runs || '100' }}
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$INSTANCE_ID" ]]; then
+            echo "::error::secret ${{ matrix.target.instance_secret }} is not set"
+            exit 1
+          fi
+
+          # SSM runs as root, but the repo, .env and the git deploy key all
+          # belong to ubuntu, so drop to that user. A login shell alone won't
+          # pick up nvm (Ubuntu's .bashrc returns early when non-interactive),
+          # hence the explicit source.
+          inner="export NVM_DIR=\"\$HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"; cd /home/ubuntu/browserarena && ./scripts/run-and-publish.sh --region $SCRIPT_REGION --provider $PROVIDERS --runs $RUNS $DRY_RUN"
+
+          # Full output goes to a file; only the tail comes back through SSM,
+          # which truncates StandardOutputContent at 24k characters.
+          read -r -d '' remote <<EOF || true
+          set -uo pipefail
+          log=/tmp/browserarena-$SCRIPT_REGION.log
+          runuser -l ubuntu -c '$inner' > "\$log" 2>&1
+          rc=\$?
+          echo "----- tail of \$log (exit \$rc) -----"
+          tail -c 20000 "\$log"
+          exit \$rc
+          EOF
+
+          jq -n --arg cmd "$remote" '{
+            commands: [$cmd],
+            executionTimeout: ["10800"],
+            workingDirectory: ["/home/ubuntu/browserarena"]
+          }' > /tmp/ssm-params.json
+
+          command_id=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --parameters file:///tmp/ssm-params.json \
+            --comment "browserarena $SCRIPT_REGION" \
+            --query 'Command.CommandId' --output text)
+
+          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          echo "Sent $command_id to $INSTANCE_ID ($SCRIPT_REGION, providers=$PROVIDERS, runs=$RUNS)"
+
+      - name: Wait for the run to finish
+        env:
+          COMMAND_ID: ${{ steps.send.outputs.command_id }}
+          INSTANCE_ID: ${{ steps.send.outputs.instance_id }}
+        run: |
+          set -uo pipefail
+
+          elapsed=0
+          while true; do
+            # The invocation isn't queryable for the first second or two.
+            status=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+              --query 'Status' --output text 2>/dev/null || echo "Pending")
+
+            case "$status" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+
+            # Heartbeat every 5 min; a full us-east run takes about an hour.
+            if (( elapsed % 300 == 0 )); then
+              echo "[${elapsed}s] $status"
+            fi
+            sleep 30
+            elapsed=$(( elapsed + 30 ))
+          done
+
+          echo "::group::Run output"
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+            --query 'StandardOutputContent' --output text
+          echo "::endgroup::"
+
+          stderr=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+            --query 'StandardErrorContent' --output text)
+          if [[ -n "$stderr" && "$stderr" != "None" ]]; then
+            echo "::group::stderr"
+            echo "$stderr"
+            echo "::endgroup::"
+          fi
+
+          echo "Final status: $status"
+          [[ "$status" == "Success" ]]
+
+      - name: Cancel the remote command if the job was cancelled
+        if: cancelled() && steps.send.outputs.command_id != ''
+        run: |
+          # Best effort: SSM stops dispatching, but a shell already running on
+          # the box may keep going to completion.
+          aws ssm cancel-command \
+            --command-id "${{ steps.send.outputs.command_id }}" \
+            --instance-ids "${{ steps.send.outputs.instance_id }}" || true

--- a/README.md
+++ b/README.md
@@ -122,17 +122,49 @@ Or deploy directly on Railway:
 
 ### Automated runs
 
-Daily results are produced by `scripts/run-and-publish.sh`, which runs the benchmark for one region's providers (c1 + c10, 100 measured sessions per concurrency level), stages only that region's `results/` slice, and pushes to `main`. Two EC2 boxes share the script; the cron line differs only in `--region`:
+Daily results are produced by `scripts/run-and-publish.sh`, which runs the benchmark for one region's providers (c1 + c10, 100 measured sessions per concurrency level), stages only that region's `results/` slice, and pushes to `main`.
 
-```cron
-# us-east-1 box (Steel, Kernel, Hyperbrowser, Anchor Browser, Browser Use)
-0 3 * * * /home/ubuntu/browserarena/scripts/run-and-publish.sh --region us-east
+The scheduler is the [`Benchmark` workflow](.github/workflows/benchmark.yml). It does not run the benchmark on a GitHub runner — it triggers the script on the EC2 box for each region via [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/run-command.html) Run Command, then streams the status and tails the log back into the Actions run. Provider API keys, the benchmark itself, and the push to `main` all stay on the instance.
 
-# us-west-1 box (Notte, Browserbase) — staggered 1h to avoid push races
-0 4 * * * /home/ubuntu/browserarena/scripts/run-and-publish.sh --region us-west
+```
+GitHub Actions (cron)  ──OIDC──>  AWS SSM  ──>  EC2 box  ──>  run-and-publish.sh  ──>  push to main
 ```
 
-Per-EC2 setup: clone the repo, populate `.env` with that region's provider keys, and add an SSH key as a [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys) with write access (one key per box). Cron logs go to `logs/` (gitignored).
+Two schedules, one per region, matching the times the boxes previously used. `us-east` runs eight providers and takes about an hour, so `us-west` is staggered behind it to keep the two `git push`es apart:
+
+| Schedule (UTC) | Region | Providers |
+|---|---|---|
+| `0 3 * * *` | us-east-1 | Steel, Kernel, Kernel (headful), Hyperbrowser, Anchor Browser, Browser Use, Browserbase, Tilion |
+| `0 4 * * *` | us-west-1 | Notte |
+
+The workflow can also be dispatched manually with `region` (`both`, `us-east-1`, `us-west-1`), `provider` (`all` or a single provider), `runs`, and `dry_run`. Picking `region: both` with a single provider narrows to whichever box owns it, so `provider: notte` only ever dispatches to us-west-1. Requesting a provider from the wrong box fails before any provider quota is spent.
+
+```bash
+# Same thing locally on a box, bypassing GitHub
+scripts/run-and-publish.sh --region us-west --provider notte --runs 100
+scripts/run-and-publish.sh --region us-east --provider all --dry-run
+```
+
+Only one run per box happens at a time; a second dispatch queues rather than cancelling the in-flight benchmark.
+
+#### Setup
+
+Per EC2 box:
+
+1. Clone the repo to `/home/ubuntu/browserarena` and populate `.env` with that region's provider keys.
+2. Add an SSH key as a [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys) with write access (one key per box), so the box can push results.
+3. Ensure the SSM agent is running and the instance profile grants `AmazonSSMManagedInstanceCore`. No inbound ports are needed — the agent polls outbound.
+4. Remove any leftover `run-and-publish.sh` crontab entry. The workflow is the only scheduler; leaving cron in place would run the benchmark twice a day and double provider spend.
+
+In the repo, create an IAM role trusting GitHub's OIDC provider (scoped to this repo) with permission to call `ssm:SendCommand`, `ssm:GetCommandInvocation`, and `ssm:CancelCommand` on the two instances, then set three secrets:
+
+| Secret | Value |
+|---|---|
+| `AWS_ROLE_ARN` | ARN of the OIDC role to assume |
+| `US_EAST_1_INSTANCE_ID` | `i-...` for the us-east-1 box |
+| `US_WEST_1_INSTANCE_ID` | `i-...` for the us-west-1 box |
+
+Full run logs stay on the box in `logs/` (gitignored) and `/tmp/browserarena-<region>.log`; the Actions run shows the last 20 KB.
 
 ## License
 

--- a/scripts/run-and-publish.sh
+++ b/scripts/run-and-publish.sh
@@ -3,39 +3,63 @@
 # push the new results to main. Designed to be invoked from cron on each EC2.
 #
 # Usage:
-#   scripts/run-and-publish.sh --region us-east|us-west [--runs N] [--dry-run] [--no-reset]
+#   scripts/run-and-publish.sh --region us-east|us-west
+#     [--provider all|<csv>] [--runs N] [--dry-run] [--no-reset]
 #
-# Cron does git pull/reset + npm ci + bench + git commit/push. The two regions
+# --provider defaults to `all`, meaning every provider owned by the region.
+# A subset must be owned by --region; running a provider from the wrong box
+# fails fast because its API key only exists on the box that owns it.
+#
+# Does git pull/reset + npm ci + bench + git commit/push. The two regions
 # write to disjoint provider directories, so simultaneous runs only race on
 # `git push` itself; the retry loop handles that.
 
 set -euo pipefail
 
 REGION=""
+PROVIDER_ARG="all"
 RUNS=100
 DRY_RUN=0
 NO_RESET=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --region)    REGION="${2:-}"; shift 2 ;;
-    --region=*)  REGION="${1#*=}"; shift ;;
-    --runs)      RUNS="${2:-}"; shift 2 ;;
-    --runs=*)    RUNS="${1#*=}"; shift ;;
-    --dry-run)   DRY_RUN=1; shift ;;
-    --no-reset)  NO_RESET=1; shift ;;
+    --region)     REGION="${2:-}"; shift 2 ;;
+    --region=*)   REGION="${1#*=}"; shift ;;
+    --provider)   PROVIDER_ARG="${2:-}"; shift 2 ;;
+    --provider=*) PROVIDER_ARG="${1#*=}"; shift ;;
+    --runs)       RUNS="${2:-}"; shift 2 ;;
+    --runs=*)     RUNS="${1#*=}"; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --no-reset)   NO_RESET=1; shift ;;
     -h|--help)
-      sed -n '2,12p' "$0"; exit 0 ;;
+      sed -n '2,15p' "$0"; exit 0 ;;
     *) echo "[ERROR] unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
 case "$REGION" in
-  us-east) PROVIDERS="steel,kernel,kernel-headful,hyperbrowser,anchorbrowser,browser-use,browserbase,tilion" ;;
-  us-west) PROVIDERS="notte" ;;
+  us-east) REGION_PROVIDERS="steel,kernel,kernel-headful,hyperbrowser,anchorbrowser,browser-use,browserbase,tilion" ;;
+  us-west) REGION_PROVIDERS="notte" ;;
   "")      echo "[ERROR] --region us-east|us-west required" >&2; exit 2 ;;
   *)       echo "[ERROR] invalid --region: $REGION (want us-east or us-west)" >&2; exit 2 ;;
 esac
+
+# `all` runs the region's full list; anything else is a subset that must be
+# owned by this region, so a typo or a wrong-box dispatch fails before spending
+# any provider quota.
+if [[ -z "$PROVIDER_ARG" || "$PROVIDER_ARG" == "all" ]]; then
+  PROVIDERS="$REGION_PROVIDERS"
+else
+  IFS=',' read -ra REQUESTED <<< "$PROVIDER_ARG"
+  for p in "${REQUESTED[@]}"; do
+    if [[ ",$REGION_PROVIDERS," != *",$p,"* ]]; then
+      echo "[ERROR] provider '$p' is not run from region $REGION (owns: $REGION_PROVIDERS)" >&2
+      exit 2
+    fi
+  done
+  PROVIDERS="$PROVIDER_ARG"
+fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
@@ -44,7 +68,7 @@ mkdir -p logs
 LOG_FILE="logs/cron-$(date -u +%Y-%m-%dT%H-%M-%SZ)-${REGION}.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-echo "[INFO] start region=$REGION runs=$RUNS dry_run=$DRY_RUN no_reset=$NO_RESET repo=$REPO_ROOT"
+echo "[INFO] start region=$REGION providers=$PROVIDERS runs=$RUNS dry_run=$DRY_RUN no_reset=$NO_RESET repo=$REPO_ROOT"
 
 if [[ $NO_RESET -eq 0 ]]; then
   echo "[INFO] resetting working tree to origin/main"
@@ -139,7 +163,12 @@ GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
 GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 export GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
 
-git commit -m "results: $REGION $DATE"
+COMMIT_MSG="results: $REGION $DATE"
+if [[ "$PROVIDERS" != "$REGION_PROVIDERS" ]]; then
+  COMMIT_MSG="$COMMIT_MSG ($PROVIDERS)"
+fi
+
+git commit -m "$COMMIT_MSG"
 
 # Push with retry. Disjoint dirs across regions mean rebase always auto-applies.
 attempts=5


### PR DESCRIPTION
## What

Moves the daily benchmark schedule out of the crontabs on the two EC2 boxes and into a `Benchmark` workflow, and adds `--provider` to `run-and-publish.sh` to back the new dispatch input.

The benchmark does **not** move to a GitHub runner. The workflow assumes an IAM role via GitHub OIDC and triggers the existing script on each box through [AWS SSM Run Command](https://docs.aws.amazon.com/systems-manager/latest/userguide/run-command.html), then polls for completion and tails the log back into the Actions run. Provider API keys, the run itself, and the push to `main` all stay on the instance.

```
GitHub Actions (cron)  ──OIDC──>  AWS SSM  ──>  EC2 box  ──>  run-and-publish.sh  ──>  push to main
```

## Why

The schedule was invisible from the repo, and re-running a region or a single provider meant SSHing into a box. SSM over OIDC keeps that property that made cron attractive — no inbound ports, no long-lived credentials — while making the schedule reviewable and the runs re-triggerable.

## Behaviour

Two schedules mirror the times the crontabs used, so `us-west` stays staggered behind the longer `us-east` run:

| Schedule (UTC) | Region | Providers |
|---|---|---|
| `0 3 * * *` | us-east-1 | Steel, Kernel, Kernel (headful), Hyperbrowser, Anchor Browser, Browser Use, Browserbase, Tilion |
| `0 4 * * *` | us-west-1 | Notte |

Manual dispatch takes `region` (`both` / `us-east-1` / `us-west-1`), `provider` (`all` or one), `runs`, and `dry_run`.

A single provider is routed to whichever box owns it, so `region: both` + `provider: notte` only dispatches to us-west-1 rather than sending a guaranteed failure to us-east. `--provider` in the script re-validates region ownership independently and exits `2` before `npm ci` or any provider API call, so a wrong-box request costs nothing.

Only one run per box at a time (`concurrency` keyed on region, `cancel-in-progress: false`) — a second dispatch queues rather than killing an in-flight benchmark.

Subset runs get a tagged commit message (`results: us-east 2026-08-29 (steel,tilion)`) so manual re-runs are distinguishable from the daily ones. Nothing in the repo parses those messages.

## Before merging

1. Create an IAM role trusting GitHub's OIDC provider, scoped to this repo, allowing `ssm:SendCommand` / `ssm:GetCommandInvocation` / `ssm:CancelCommand` on the two instances.
2. Set repo secrets `AWS_ROLE_ARN`, `US_EAST_1_INSTANCE_ID`, `US_WEST_1_INSTANCE_ID`.
3. Confirm the SSM agent is running on both boxes and their instance profiles grant `AmazonSSMManagedInstanceCore`.
4. **Remove the `run-and-publish.sh` crontab entries from both boxes.** Leaving them runs the benchmark twice a day at double provider spend.

## Testing

Validated locally; the SSM/OIDC path could not be exercised outside AWS.

- `actionlint` clean on the new workflow (includes its shellcheck pass over the embedded `run` blocks)
- Rendered the generated remote command and `bash -n`'d it, confirming `$HOME` / `$NVM_DIR` / `$log` stay literal for the box while region/provider/runs are baked in
- Exercised the plan job's matrix jq across all 18 region × provider combinations, including the four that should hard-fail
- Exercised `--provider` validation across every region/provider pair, plus `--help` and an unknown region
- Ran the repo's own secret-scan pattern over the changed files

**First dispatch should be `dry_run: true` with a low `runs`.** The `/home/ubuntu/browserarena` path and node-on-PATH assumptions are inherited from the current cron setup rather than independently verified. SSM runs as root, so the remote command drops to `ubuntu` via `runuser -l` (the repo, `.env`, and the deploy key belong to that user) and explicitly sources nvm, since Ubuntu's `.bashrc` returns early for non-interactive shells.

## Notes for the reviewer

- `aws-actions/configure-aws-credentials` is pinned to `@v4`. `ci.yml` is on `checkout@v7.0.1` / `setup-node@v7`, so it's worth checking whether a newer major exists before merging.
- Unrelated pre-existing inconsistency, not touched here: the RTT table in `README.md` lists Browserbase under the **us-west-1** runner, but `run-and-publish.sh` runs it from the **us-east** box. One of the two is wrong.
- No TypeScript changed, so `npm run build` was not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
