### PR TITLE
feat(web): show Tilion region and default the value score to Fastest

### DIFF
--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -392,7 +392,9 @@ export function LeaderboardTable({
     dir: "desc",
   });
 
-  const [rawWeights, setRawWeights] = useState({ latency: 33, reliability: 33, cost: 33 });
+  // Defaults to the first preset ("Fastest") so the highlighted button and the
+  // initial weights cannot drift apart.
+  const [rawWeights, setRawWeights] = useState(WEIGHT_PRESETS[0].weights);
 
   const normalizedWeights = useMemo(() => {
     const total = rawWeights.latency + rawWeights.reliability + rawWeights.cost;

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -82,7 +82,7 @@ const PROVIDER_META: Record<
   },
   STEEL: { displayName: "Steel", url: "https://www.steel.dev", browserRegion: "us-east-1" },
   BROWSER_USE: { displayName: "Browser Use", url: "https://www.browser-use.com", browserRegion: "us-east-1" },
-  TILION: { displayName: "Tilion", url: "https://tilion.dev" },
+  TILION: { displayName: "Tilion", url: "https://tilion.dev", browserRegion: "us-east-1" },
 };
 
 function median(values: number[]): number {


### PR DESCRIPTION
Two small leaderboard changes.

## Tilion region

`PROVIDER_META.TILION` gains `browserRegion: "us-east-1"`, so the REGION column shows a value instead of a dash. Tilion was the only provider on the board without one.

## Value Score defaults to Fastest

The table previously loaded with equal weights. It now loads on the first preset.

```ts
const [rawWeights, setRawWeights] = useState(WEIGHT_PRESETS[0].weights);
```

Referencing the preset rather than repeating its numbers is deliberate. The active-button check compares the current weights against each preset by value, so a literal that drifts from the preset it is meant to mirror would leave every button unselected on load, with no other symptom. Taking the weights from the preset itself makes that impossible.

## Checks

Loaded the built page and read the state back from the DOM rather than eyeballing it:

- `Fastest` is the highlighted preset on load and the weight bar reads Reliability 0%, Latency 100%, Cost 0%.
- The other three presets still activate and deactivate correctly when clicked.
- Tilion renders `us-east-1`, `$0.03/hr`, 100 runs, 100% reliability, placing fourth on the default view.

Build and audit pass in `web`.