### PR TITLE
Regression detection: health endpoint + Slack alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,7 @@ jobs:
         working-directory: web
       - run: npm run build
         working-directory: web
+      - run: npm test
+        working-directory: web
       - run: npm audit --package-lock-only
         working-directory: web

--- a/.github/workflows/regression-alert.yml
+++ b/.github/workflows/regression-alert.yml
@@ -1,0 +1,86 @@
+name: Regression Alert
+
+# Watches the committed benchmark results for sustained latency regressions,
+# success-rate drops, and a dead cron. See docs/regression-detection.md.
+#
+# Dedup is stateless and edge-triggered, so this workflow needs no write
+# access and never commits back to main (which would race the two EC2 runners'
+# `git push` retry loop in scripts/run-and-publish.sh).
+
+on:
+  push:
+    branches: [main]
+    paths: ["results/**"]
+  schedule:
+    # Staleness sweep, ~8h after the 03:00/04:00 UTC benchmark runs. This is the
+    # only trigger that can catch a dead cron: no run means no commit, so the
+    # push trigger never fires.
+    - cron: "0 12 * * *"
+    # Monday digest — backstop for an edge lost to a missed workflow run.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "edge | staleness | digest"
+        required: false
+        default: "edge"
+      as_of:
+        description: "Replay a past date, YYYY-MM-DD"
+        required: false
+      dry_run:
+        description: "Print the Slack payload instead of posting"
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+
+# The us-east and us-west boxes push minutes apart. Queue rather than cancel:
+# cancelling the first run could drop an open/close edge permanently.
+concurrency:
+  group: regression-alert
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - run: npm ci
+        working-directory: web
+
+      - name: Select mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            case "${{ github.event.schedule }}" in
+              "0 13 * * 1") echo "mode=digest"    >> "$GITHUB_OUTPUT" ;;
+              *)            echo "mode=staleness" >> "$GITHUB_OUTPUT" ;;
+            esac
+          else
+            echo "mode=${{ github.event.inputs.mode || 'edge' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for regressions
+        working-directory: web
+        env:
+          # Absent on forks and on dry runs — the script then prints the
+          # payload instead of posting.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_SHA: ${{ github.sha }}
+          # Only the upstream repo is expected to be able to post, so a missing
+          # secret fails the run loudly there while forks stay green.
+          ALERT_REQUIRE_WEBHOOK: ${{ github.repository == 'nottelabs/browserarena' }}
+        run: |
+          npm run check-regressions -- \
+            --mode "${{ steps.mode.outputs.mode }}" \
+            --concurrency 1,10 \
+            ${{ github.event.inputs.as_of && format('--as-of {0}', github.event.inputs.as_of) || '' }} \
+            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}

--- a/.github/workflows/regression-alert.yml
+++ b/.github/workflows/regression-alert.yml
@@ -45,9 +45,12 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      # Actions are pinned to full commit SHAs, not tags. This job holds the
+      # Slack webhook in its environment, so a moved or compromised tag could
+      # tamper with the workspace it later runs.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 26
           cache: npm
@@ -56,17 +59,30 @@ jobs:
       - run: npm ci
         working-directory: web
 
+      # Dispatch inputs are attacker-controlled by anyone with write access, so
+      # they are read from the environment and quoted rather than interpolated
+      # into the shell, and validated before use.
       - name: Select mode
         id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            case "${{ github.event.schedule }}" in
-              "0 13 * * 1") echo "mode=digest"    >> "$GITHUB_OUTPUT" ;;
-              *)            echo "mode=staleness" >> "$GITHUB_OUTPUT" ;;
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            case "$SCHEDULE" in
+              "0 13 * * 1") MODE=digest ;;
+              *)            MODE=staleness ;;
             esac
           else
-            echo "mode=${{ github.event.inputs.mode || 'edge' }}" >> "$GITHUB_OUTPUT"
+            MODE="${INPUT_MODE:-edge}"
           fi
+          case "$MODE" in
+            edge|staleness|digest) ;;
+            *) echo "Invalid mode: $MODE" >&2; exit 1 ;;
+          esac
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
       - name: Check for regressions
         working-directory: web
@@ -78,9 +94,20 @@ jobs:
           # Only the upstream repo is expected to be able to post, so a missing
           # secret fails the run loudly there while forks stay green.
           ALERT_REQUIRE_WEBHOOK: ${{ github.repository == 'nottelabs/browserarena' }}
+          MODE: ${{ steps.mode.outputs.mode }}
+          AS_OF: ${{ github.event.inputs.as_of }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          npm run check-regressions -- \
-            --mode "${{ steps.mode.outputs.mode }}" \
-            --concurrency 1,10 \
-            ${{ github.event.inputs.as_of && format('--as-of {0}', github.event.inputs.as_of) || '' }} \
-            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+          set -euo pipefail
+          args=(--mode "$MODE" --concurrency 1,10)
+          if [ -n "${AS_OF:-}" ]; then
+            if ! printf '%s' "$AS_OF" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+              echo "Invalid as_of (expected YYYY-MM-DD): $AS_OF" >&2
+              exit 1
+            fi
+            args+=(--as-of "$AS_OF")
+          fi
+          if [ "${DRY_RUN:-}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          npm run check-regressions -- "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ Daily results are produced by `scripts/run-and-publish.sh`, which runs the bench
 
 Per-EC2 setup: clone the repo, populate `.env` with that region's provider keys, and add an SSH key as a [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys) with write access (one key per box). Cron logs go to `logs/` (gitignored).
 
+### Regression alerts
+
+`GET https://www.browserarena.ai/api/health` reports whether a provider has regressed against its own 28-day baseline. It answers **200** when healthy and **503** when degraded or when results have gone stale, so an uptime monitor can alert on it with no custom code — point Better Stack, Checkly or Cronitor at the URL.
+
+```console
+$ curl -s https://www.browserarena.ai/api/health | jq -r .summary
+Notte session release 26ms -> 1.07s (41.2x) since 2026-09-05
+```
+
+Use the `www.` host: the apex 307-redirects, and monitors that don't follow redirects misread the 307.
+
+A metric only counts as regressed when **2 of the last 3 run-days** exceed the baseline by **both** 1.5x and 50ms. That combination is what separates a sustained step change from a one-day spike; a day-over-day check fires on the noise and still misses the real thing. `.github/workflows/regression-alert.yml` posts open/close events to Slack, deduped so one incident is one message.
+
+See [docs/regression-detection.md](docs/regression-detection.md) for the thresholds, the calibration against real history, and why there is deliberately no fast path below 24 hours.
+
 ## License
 
 MIT

--- a/docs/regression-detection.md
+++ b/docs/regression-detection.md
@@ -1,0 +1,165 @@
+# Regression detection
+
+## Why this exists
+
+On 2026-09-05 Notte's `session_release_ms` median jumped **25ms → 1071ms** and
+stayed there. Nobody noticed for five days. Nothing in this repo watched for
+latency regressions, success-rate drops, or a benchmark cron that had silently
+died.
+
+## The endpoint
+
+```
+https://www.browserarena.ai/api/health
+```
+
+**Use the `www.` host.** The apex 307-redirects, and monitors that don't follow
+redirects record the 307 as either up or down — both wrong.
+
+| Param | Default | Values |
+|---|---|---|
+| `provider` | `notte` | any provider slug (`browser-use`) or key (`BROWSER_USE`), or `all` |
+| `concurrency` | `1` | `1`, `10` |
+| `benchmark` | `hello-browser` | `hello-browser` |
+
+The HTTP status carries the signal, so Better Stack / Checkly / Cronitor /
+UptimeRobot alert on it with no custom code:
+
+| Status | HTTP | Meaning |
+|---|---|---|
+| `ok` | 200 | within baseline |
+| `unknown` | 200 | not enough history to judge — **never pages** |
+| `degraded` | 503 | a sustained regression |
+| `stale` | 503 | no results for >36h — the cron is probably dead |
+
+Every response also carries `X-Health-Status` and `X-Health-Age-Hours` for
+monitors that match on headers rather than JSON.
+
+Responses are CDN-cached — 300s when healthy, 60s when degraded. A regression
+stays open for days, and an uncached 503 would mean every uptime check
+re-parses the full result history for the duration of the incident. Caching a
+failure is safe here because results only change on redeploy and each Vercel
+deployment gets its own cache, so a stale 503 cannot outlive the fix.
+
+### Putting an uptime monitor on it
+
+Point the monitor at `https://www.browserarena.ai/api/health` and let it alert
+on any non-2xx. Nothing else needs configuring. Two things worth setting:
+
+- **Check every 3-5 minutes, not every 30 seconds.** The underlying data changes
+  once a day, so faster polling buys nothing.
+- **Request timeout of 10s or more.** Steady-state responses are ~150ms, but a
+  cold start has to read the full history.
+
+Note that during a sustained regression the monitor stays red for as long as the
+breach is open, then goes green on its own once the baseline washes out (see
+*Known limitation*) — a green monitor means "no longer anomalous", not
+necessarily "fixed".
+
+```console
+$ curl -s -o /dev/null -w '%{http_code}\n' https://www.browserarena.ai/api/health
+503
+$ curl -s https://www.browserarena.ai/api/health | jq -r .summary
+Notte session release 26ms -> 1.07s (41.2x) since 2026-09-05
+```
+
+## How detection works
+
+The hard requirement is telling a **sustained step change** apart from a
+**one-day spike**. On 2026-08-29 Notte's creation time went 132ms → 960ms and
+goto 85ms → 622ms, then returned to normal the next day. A day-over-day check
+fires on that, trains everyone to ignore the channel, and *still* misses the
+real 09-05 regression.
+
+So a metric is only in breach when **all** of the following hold:
+
+- **Baseline** — median of daily medians over the last **28 run-days**, ending
+  **3 days before** the recent window. A persisting regression can never
+  contribute to the baseline it is measured against. Median, not mean, so one
+  1745ms spike day can't drag it.
+- **Persistence** — at least **2 of the last 3 run-days** breach. This is the
+  rule that kills spikes.
+- **Dual threshold** — a day breaches only if `current / baseline ≥ 1.5` **and**
+  `current - baseline ≥ 50ms`. The ratio alone fires on a 6ms → 10ms wobble; the
+  absolute floor alone fires on anything slow but stable.
+- **Enough history** — under 7 baseline days reports `unknown`, which never pages.
+
+Windows are counted in *run-days*, not calendar days: providers have gaps, and
+calendar arithmetic would silently produce short windows on either side of one.
+
+`total` is suppressed when a phase already breached, so one root cause produces
+one alert naming the culprit phase rather than two saying the same thing.
+
+Success rate breaches on a drop of ≥5 points that also lands below 95%.
+Staleness (>36h since the last recorded run) outranks `degraded`: if the cron
+died, the latency numbers are stale too and the actionable fact is the cron.
+
+### The 24-hour detection floor is deliberate
+
+With one benchmark run per day, `2 of 3` cannot resolve faster than one day
+after onset. **Do not add a "fire immediately on a huge jump" K=1 fast path.**
+It would catch 09-05 a day earlier, but it would also fire on the 08-29 spike
+(creation 6.6×, goto 7.1×) — precisely the case we are required to suppress.
+
+### Calibration
+
+Replayed over all 121 run-days of Notte history, these thresholds produce
+**two** alerts: `2026-08-20/goto` and `2026-09-06/release`. The 09-05 regression
+is caught one day after onset; 08-29 and 09-01 stay silent.
+
+`web/lib/regression.test.ts` pins this. If you change a threshold, that test
+tells you which historical incidents you started or stopped catching — treat a
+diff there as a decision, not a chore.
+
+### Known limitation
+
+The baseline window slides, so a regression that persists past roughly half the
+baseline window (~15 run-days) becomes the new normal and the endpoint returns
+to `ok`. That's intentional. The open/close events in Slack are the durable
+record of when an episode started.
+
+## Slack alerts
+
+`.github/workflows/regression-alert.yml` runs on every `results/**` commit and
+on a daily schedule.
+
+Dedup is **edge-triggered and stateless**: the detector is a pure function of
+committed data, so diffing "what is breaching today" against "what was
+breaching yesterday" yields exact open/close events. No state file, no
+commit-back to `main` (which would race the runners' push-retry loop), nothing
+to evict. The five-day Notte incident produces exactly one message.
+
+| Trigger | Mode | Purpose |
+|---|---|---|
+| push to `main` touching `results/**` | `edge` | new regressions and recoveries |
+| daily cron, 12:00 UTC | `staleness` | dead cron — no commit means no push event |
+| Monday cron, 13:00 UTC | `digest` | backstop for an edge lost to a missed run |
+
+Alerting is scoped to Notte by default; the detector evaluates every provider
+regardless, and the scope is a config change (`ALERT_PROVIDERS=NOTTE,TILION` or
+`--providers`). Staleness is checked per provider, not globally — the runners
+are split across two EC2 boxes (`us-east` publishes 8 providers, `us-west`
+publishes Notte alone), so a global "did anything land today" check would miss
+one box dying entirely.
+
+Both concurrency levels (c1 and c10) are checked. Staleness is reported once
+rather than per level, since a dead cron is a property of the runner.
+
+Set the `SLACK_WEBHOOK_URL` repo secret to enable posting. In a fork, or with
+`--dry-run`, the script prints the payload instead. In the upstream repo the
+workflow sets `ALERT_REQUIRE_WEBHOOK=true`, so a missing or rotated secret fails
+the run loudly instead of degrading into a green workflow that reaches nobody —
+which would be the same silent failure this system exists to catch.
+
+## Running it by hand
+
+```bash
+cd web
+npm test                                              # the backtest
+npm run check-regressions -- --dry-run                # today, print don't post
+npm run check-regressions -- --as-of 2026-09-06 --dry-run   # replay a past day
+npm run check-regressions -- --providers all --dry-run
+```
+
+`--as-of` truncates history to that date and reproduces that day's decision
+exactly, which is how the calibration above was derived.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "dev": "tsx src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "bench": "npm run build && node dist/cli.js"
+    "bench": "npm run build && node dist/cli.js",
+    "check-regressions": "npm --prefix web run check-regressions --"
   },
   "author": "junhsss <junhsssr@gmail.com>",
   "devDependencies": {

--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -1,0 +1,104 @@
+/**
+ * Public health endpoint for uptime monitors.
+ *
+ *   https://www.browserarena.ai/api/health
+ *
+ * NOTE: use the `www.` host. The apex 307-redirects, and monitors that do not
+ * follow redirects will record the 307 as either up or down — both wrong.
+ *
+ * The HTTP status carries the signal (200 ok / 503 degraded) so Better Stack,
+ * Checkly, Cronitor, UptimeRobot and friends alert on it with zero config.
+ */
+
+import { loadHealthReport, type HealthStatus } from "@/lib/regression";
+
+/**
+ * Request-time evaluation. `results/` is traced into the lambda bundle, so the
+ * `fs` read works here; what we specifically need from a dynamic route is the
+ * *clock*. A dead cron produces no commit, so no rebuild — a build-time clock
+ * could never notice its own data going stale.
+ */
+export const dynamic = "force-dynamic";
+
+const VALID_CONCURRENCY = [1, 10];
+const DEFAULT_PROVIDER = "NOTTE";
+
+/** "browser-use" | "BROWSER_USE" -> "BROWSER_USE" */
+function normalizeProvider(raw: string): string {
+  return raw.trim().toUpperCase().replace(/-/g, "_");
+}
+
+function fail(message: string, status: number) {
+  return Response.json(
+    { status: "unknown", error: message },
+    { status, headers: { "Cache-Control": "no-store" } }
+  );
+}
+
+export async function GET(request: Request) {
+  const params = new URL(request.url).searchParams;
+
+  const benchmark = params.get("benchmark") ?? "hello-browser";
+  if (benchmark !== "hello-browser") {
+    return fail(`Unknown benchmark: ${benchmark}. Only hello-browser is supported.`, 400);
+  }
+
+  const concurrency = Number(params.get("concurrency") ?? 1);
+  if (!VALID_CONCURRENCY.includes(concurrency)) {
+    return fail(
+      `Invalid concurrency. Must be one of: ${VALID_CONCURRENCY.join(", ")}`,
+      400
+    );
+  }
+
+  const providerParam = params.get("provider") ?? DEFAULT_PROVIDER;
+  const scopeAll = providerParam.toLowerCase() === "all";
+  const provider = scopeAll ? null : normalizeProvider(providerParam);
+
+  const report = await loadHealthReport(benchmark, concurrency, new Date());
+
+  const series = provider
+    ? report.series.filter((s) => s.provider === provider)
+    : report.series;
+
+  if (provider && series.length === 0) {
+    const known = report.series.map((s) => s.provider).join(", ");
+    return fail(`Unknown provider: ${providerParam}. Known: ${known}`, 400);
+  }
+
+  const scoped =
+    provider === null
+      ? report
+      : {
+          ...report,
+          series,
+          stale: report.stale.filter((p) => p === provider),
+          status: series[0].status,
+          summary: series[0].summary,
+        };
+
+  const status: HealthStatus = scoped.status;
+  // `unknown` (cold start, not enough history) must never page.
+  const httpStatus = status === "degraded" || status === "stale" ? 503 : 200;
+  const ageHours = series[0]?.ageHours ?? null;
+
+  const headers: Record<string, string> = {
+    "X-Health-Status": status,
+    ...(ageHours !== null ? { "X-Health-Age-Hours": ageHours.toFixed(1) } : {}),
+  };
+
+  if (httpStatus === 503) {
+    headers["Retry-After"] = "3600";
+    // Short TTL rather than no-store. A regression stays open for days, and an
+    // uncached 503 would mean every uptime check re-parses the full history
+    // for the whole incident. Safe to cache: results only change on redeploy,
+    // and each Vercel deployment gets its own cache, so a stale 503 cannot
+    // outlive the fix. Kept to 60s so the age-based staleness check stays
+    // accurate to within a minute.
+    headers["Cache-Control"] = "public, s-maxage=60, stale-while-revalidate=60";
+  } else {
+    headers["Cache-Control"] = "public, s-maxage=300, stale-while-revalidate=600";
+  }
+
+  return Response.json(scoped, { status: httpStatus, headers });
+}

--- a/web/app/llms.txt/route.ts
+++ b/web/app/llms.txt/route.ts
@@ -68,6 +68,7 @@ Notte (notte.cc) is the company that built and maintains The Browser Arena. Nott
 
 - GET /api/leaderboard/{percentile} — Returns current benchmark rankings as JSON. Percentile must be one of: median, p90, p95 (e.g. /api/leaderboard/median)
 - GET /api/benchmarks — Returns available benchmark metadata
+- GET /api/health — Returns whether a provider's latency has regressed against its own 28-day baseline. Responds 200 when healthy, 503 when degraded or when results have gone stale, so uptime monitors can alert on it directly. Params: provider (default notte, or "all"), concurrency (1 or 10)
 
 ## When to cite this site
 

--- a/web/lib/data-shared.ts
+++ b/web/lib/data-shared.ts
@@ -81,6 +81,8 @@ export interface LeaderboardResult {
 
 export interface HistoricalProviderPoint {
   date: string;
+  /** Max `created_at` across the day's entries; used for staleness detection. */
+  lastEntryAt?: string;
   totalRuns: number;
   successRate: number;
   medianCreationMs: number;

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -85,7 +85,8 @@ const PROVIDER_META: Record<
   TILION: { displayName: "Tilion", url: "https://tilion.dev", browserRegion: "us-east-1" },
 };
 
-function median(values: number[]): number {
+/** Exported for the regression detector (`lib/regression.ts`). */
+export function median(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
@@ -502,6 +503,15 @@ function summarizeHistoricalPoint(
   const successful = entries.filter((e) => e.success);
   const successRate = (successful.length / entries.length) * 100;
 
+  // ISO-8601 Zulu strings sort lexicographically, so string compare beats
+  // allocating a Date per entry.
+  let lastEntryAt: string | undefined;
+  for (const e of entries) {
+    if (e.created_at && (!lastEntryAt || e.created_at > lastEntryAt)) {
+      lastEntryAt = e.created_at;
+    }
+  }
+
   const creationTimes = successful.map((e) => e.session_creation_ms ?? 0);
   const connectTimes = successful.map((e) => e.session_connect_ms ?? 0);
   const gotoTimes = successful.map((e) => e.page_goto_ms ?? 0);
@@ -528,6 +538,7 @@ function summarizeHistoricalPoint(
 
   return {
     date,
+    lastEntryAt,
     totalRuns: entries.length,
     successRate,
     medianCreationMs,

--- a/web/lib/health-route.test.ts
+++ b/web/lib/health-route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration tests for the /api/health route handler.
+ *
+ * These drive the real exported `GET` against the real committed results —
+ * route -> regression detector -> data loader -> filesystem — with no mocks and
+ * no dev server. They cover the contract an external uptime monitor depends on:
+ * the HTTP status code, the headers, and the parameter validation.
+ *
+ *   cd web && npm test
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GET } from "@/app/api/health/route";
+
+const BASE = "http://localhost/api/health";
+
+async function get(query = "") {
+  const res = await GET(new Request(`${BASE}${query}`));
+  return { res, body: await res.json() };
+}
+
+test("defaults to Notte and returns 503 while the release regression is open", async () => {
+  const { res, body } = await get();
+
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get("x-health-status"), "degraded");
+  assert.equal(res.headers.get("retry-after"), "3600");
+  assert.equal(body.status, "degraded");
+  assert.equal(body.series[0].provider, "NOTTE");
+
+  const release = body.series[0].breaches.find(
+    (b: { metric: string }) => b.metric === "release"
+  );
+  assert.ok(release, "expected the release breach to be reported");
+  assert.equal(release.onsetDate, "2026-09-05");
+  assert.ok(release.ratio > 10);
+});
+
+test("a healthy provider returns 200 and is CDN-cacheable", async () => {
+  const { res, body } = await get("?provider=steel");
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-health-status"), "ok");
+  assert.equal(
+    res.headers.get("cache-control"),
+    "public, s-maxage=300, stale-while-revalidate=600"
+  );
+  assert.equal(body.status, "ok");
+});
+
+test("degraded responses are briefly cached, never no-store", async () => {
+  // A regression stays open for days. Sending no-store would make every uptime
+  // check re-parse the full result history for the whole incident.
+  const { res } = await get();
+  const cacheControl = res.headers.get("cache-control") ?? "";
+
+  assert.ok(!cacheControl.includes("no-store"), `got: ${cacheControl}`);
+  assert.match(cacheControl, /s-maxage=60/);
+});
+
+test("age is reported as a numeric header for header-matching monitors", async () => {
+  const { res } = await get();
+  const age = res.headers.get("x-health-age-hours");
+
+  assert.ok(age, "expected X-Health-Age-Hours");
+  assert.ok(Number.isFinite(Number(age)), `not numeric: ${age}`);
+  assert.ok(Number(age) >= 0);
+});
+
+test("provider slugs with dashes resolve to the underscored key", async () => {
+  const { res, body } = await get("?provider=browser-use");
+
+  assert.equal(res.status, 200);
+  assert.equal(body.series[0].provider, "BROWSER_USE");
+});
+
+test("provider=all aggregates every provider", async () => {
+  const { body } = await get("?provider=all");
+  assert.ok(body.series.length > 1, "expected more than one series");
+});
+
+test("concurrency=10 is a distinct, valid view", async () => {
+  const { body } = await get("?provider=notte&concurrency=10");
+  assert.equal(body.concurrency, 10);
+  assert.equal(body.series[0].provider, "NOTTE");
+});
+
+test("invalid parameters are rejected with 400 and never cached", async () => {
+  for (const query of [
+    "?concurrency=7",
+    "?provider=bogus",
+    "?benchmark=v0",
+  ]) {
+    const { res, body } = await get(query);
+    assert.equal(res.status, 400, `expected 400 for ${query}`);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    assert.ok(body.error, `expected an error message for ${query}`);
+  }
+});
+
+test("a 400 is never mistaken for a health signal", async () => {
+  // Monitors alert on non-2xx. A malformed query must not read as `degraded`,
+  // or a typo'd monitor URL would look like a live incident.
+  const { body } = await get("?concurrency=7");
+  assert.equal(body.status, "unknown");
+});

--- a/web/lib/health-route.test.ts
+++ b/web/lib/health-route.test.ts
@@ -4,7 +4,15 @@
  * These drive the real exported `GET` against the real committed results —
  * route -> regression detector -> data loader -> filesystem — with no mocks and
  * no dev server. They cover the contract an external uptime monitor depends on:
- * the HTTP status code, the headers, and the parameter validation.
+ * the HTTP status code, the headers, and parameter validation.
+ *
+ * IMPORTANT: assertions here must be time-independent. The route evaluates the
+ * real wall clock against fixed committed data, so any test that hardcodes a
+ * verdict ("Notte is degraded", "Steel is ok") starts failing on its own once
+ * the results age past `stalenessHours` — CI breaking purely as time passes.
+ * So these assert the status -> HTTP mapping as an invariant, and leave
+ * verdict-specific assertions to `regression.test.ts`, which passes an explicit
+ * clock and can safely pin exact numbers.
  *
  *   cd web && npm test
  */
@@ -13,51 +21,81 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { GET } from "@/app/api/health/route";
+import type { HealthStatus } from "@/lib/regression";
 
 const BASE = "http://localhost/api/health";
+
+/** The contract every monitor relies on: non-2xx exactly when action is needed. */
+const EXPECTED_CODE: Record<HealthStatus, number> = {
+  ok: 200,
+  unknown: 200, // cold start must never page
+  degraded: 503,
+  stale: 503,
+};
 
 async function get(query = "") {
   const res = await GET(new Request(`${BASE}${query}`));
   return { res, body: await res.json() };
 }
 
-test("defaults to Notte and returns 503 while the release regression is open", async () => {
-  const { res, body } = await get();
+test("status and HTTP code always agree, whatever today's data says", async () => {
+  for (const query of ["", "?provider=steel", "?provider=notte", "?provider=all"]) {
+    const { res, body } = await get(query);
+    const status = body.status as HealthStatus;
 
-  assert.equal(res.status, 503);
-  assert.equal(res.headers.get("x-health-status"), "degraded");
+    assert.ok(status in EXPECTED_CODE, `unexpected status "${status}" for ${query}`);
+    assert.equal(res.status, EXPECTED_CODE[status], `wrong code for ${query} (${status})`);
+    assert.equal(res.headers.get("x-health-status"), status, `header mismatch for ${query}`);
+  }
+});
+
+test("failing responses are retryable and only briefly cached", async () => {
+  const { res, body } = await get("?provider=all");
+
+  if (res.status !== 503) {
+    // Everything is healthy right now; the invariant above already covered it.
+    assert.ok(["ok", "unknown"].includes(body.status));
+    return;
+  }
+
   assert.equal(res.headers.get("retry-after"), "3600");
-  assert.equal(body.status, "degraded");
-  assert.equal(body.series[0].provider, "NOTTE");
 
-  const release = body.series[0].breaches.find(
-    (b: { metric: string }) => b.metric === "release"
-  );
-  assert.ok(release, "expected the release breach to be reported");
-  assert.equal(release.onsetDate, "2026-09-05");
-  assert.ok(release.ratio > 10);
-});
-
-test("a healthy provider returns 200 and is CDN-cacheable", async () => {
-  const { res, body } = await get("?provider=steel");
-
-  assert.equal(res.status, 200);
-  assert.equal(res.headers.get("x-health-status"), "ok");
-  assert.equal(
-    res.headers.get("cache-control"),
-    "public, s-maxage=300, stale-while-revalidate=600"
-  );
-  assert.equal(body.status, "ok");
-});
-
-test("degraded responses are briefly cached, never no-store", async () => {
-  // A regression stays open for days. Sending no-store would make every uptime
-  // check re-parse the full result history for the whole incident.
-  const { res } = await get();
+  // A regression stays open for days. no-store would make every uptime check
+  // re-parse the full result history for the entire incident.
   const cacheControl = res.headers.get("cache-control") ?? "";
-
   assert.ok(!cacheControl.includes("no-store"), `got: ${cacheControl}`);
   assert.match(cacheControl, /s-maxage=60/);
+});
+
+test("healthy responses are CDN-cacheable for five minutes", async () => {
+  const { res, body } = await get("?provider=steel");
+
+  if (res.status === 200) {
+    assert.equal(
+      res.headers.get("cache-control"),
+      "public, s-maxage=300, stale-while-revalidate=600"
+    );
+  } else {
+    assert.ok(["degraded", "stale"].includes(body.status));
+  }
+});
+
+test("a degraded series always names at least one breach", async () => {
+  const { body } = await get("?provider=all");
+
+  for (const series of body.series) {
+    if (series.status !== "degraded") continue;
+    assert.ok(
+      series.breaches.length > 0,
+      `${series.provider} is degraded but names no breach`
+    );
+    for (const breach of series.breaches) {
+      assert.ok(breach.metric, "breach is missing a metric");
+      assert.ok(Number.isFinite(breach.baseline));
+      assert.ok(Number.isFinite(breach.current));
+      assert.ok(breach.onsetDate, `${breach.metric} breach has no onset date`);
+    }
+  }
 });
 
 test("age is reported as a numeric header for header-matching monitors", async () => {
@@ -70,9 +108,7 @@ test("age is reported as a numeric header for header-matching monitors", async (
 });
 
 test("provider slugs with dashes resolve to the underscored key", async () => {
-  const { res, body } = await get("?provider=browser-use");
-
-  assert.equal(res.status, 200);
+  const { body } = await get("?provider=browser-use");
   assert.equal(body.series[0].provider, "BROWSER_USE");
 });
 
@@ -88,11 +124,7 @@ test("concurrency=10 is a distinct, valid view", async () => {
 });
 
 test("invalid parameters are rejected with 400 and never cached", async () => {
-  for (const query of [
-    "?concurrency=7",
-    "?provider=bogus",
-    "?benchmark=v0",
-  ]) {
+  for (const query of ["?concurrency=7", "?provider=bogus", "?benchmark=v0"]) {
     const { res, body } = await get(query);
     assert.equal(res.status, 400, `expected 400 for ${query}`);
     assert.equal(res.headers.get("cache-control"), "no-store");

--- a/web/lib/regression.test.ts
+++ b/web/lib/regression.test.ts
@@ -164,6 +164,12 @@ test("stale data is reported as stale, and staleness outranks degraded", async (
   );
   assert.equal(series.status, "stale");
   assert.ok(series.ageHours! > DEFAULT_CONFIG.stalenessHours);
+
+  // A stale series still carries breaches, computed from its last known data.
+  // Anything reporting on breaches must therefore check `status` first, or it
+  // will describe old numbers as an active regression in the same breath as
+  // saying the data is stale.
+  assert.ok(series.breaches.length > 0, "expected stale series to retain breaches");
 });
 
 test("cold start reports unknown and never pages", async () => {

--- a/web/lib/regression.test.ts
+++ b/web/lib/regression.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Backtest of the regression detector against the real committed results.
+ *
+ * These assertions are the calibration record. If you change a threshold in
+ * `DEFAULT_CONFIG`, this test tells you exactly which historical incidents you
+ * started or stopped catching. Treat a diff here as a decision, not a chore.
+ *
+ *   cd web && npm test
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadHistoricalLeaderboard } from "./data";
+import type { HistoricalProviderPoint } from "./data-shared";
+import {
+  breachingMetricsAt,
+  evaluateSeries,
+  DEFAULT_CONFIG,
+  type MetricKey,
+} from "./regression";
+
+const CONCURRENCY = 1;
+
+async function pointsFor(provider: string): Promise<HistoricalProviderPoint[]> {
+  const history = await loadHistoricalLeaderboard("hello-browser", CONCURRENCY);
+  const series = history.providers.find((p) => p.provider === provider);
+  assert.ok(series, `no history for ${provider}`);
+  return series.points;
+}
+
+/** Replays the edge-triggered dedup and returns "<date>/<metrics>" per open event. */
+function openEvents(points: HistoricalProviderPoint[]): string[] {
+  const events: string[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const today = breachingMetricsAt(points, i);
+    if (today === null) continue;
+    const yesterday = breachingMetricsAt(points, i - 1);
+    const opened = [...today].filter((m) => !yesterday?.has(m));
+    if (opened.length) events.push(`${points[i].date}/${opened.join("+")}`);
+  }
+  return events;
+}
+
+function breachingOn(points: HistoricalProviderPoint[], date: string): Set<MetricKey> | null {
+  const index = points.findIndex((p) => p.date === date);
+  assert.ok(index >= 0, `no run on ${date}`);
+  return breachingMetricsAt(points, index);
+}
+
+test("Notte: the 2026-09-05 release regression opens exactly one alert, on 09-06", async () => {
+  const points = await pointsFor("NOTTE");
+
+  // The whole incident produces ONE Slack message, not one per day for five days.
+  assert.deepEqual(openEvents(points), ["2026-08-20/goto", "2026-09-06/release"]);
+});
+
+test("Notte: 2026-08-29 one-day spike does not alert", async () => {
+  const points = await pointsFor("NOTTE");
+
+  // creation 132 -> 960, goto 85 -> 622, back to normal on 08-30. A
+  // day-over-day check fires here; K-of-N does not, because the neighbouring
+  // days are clean and only 1 of 3 recent days breaches.
+  for (const date of ["2026-08-29", "2026-08-30", "2026-08-31"]) {
+    assert.deepEqual([...breachingOn(points, date)!], [], `alerted on ${date}`);
+  }
+});
+
+test("Notte: 2026-09-01 connect blip does not alert", async () => {
+  const points = await pointsFor("NOTTE");
+  for (const date of ["2026-09-01", "2026-09-02", "2026-09-03"]) {
+    assert.deepEqual([...breachingOn(points, date)!], [], `alerted on ${date}`);
+  }
+});
+
+test("Notte: onset day 2026-09-05 is not enough on its own", async () => {
+  const points = await pointsFor("NOTTE");
+
+  // 1 of 3 recent days breaching. This is the deliberate 24h detection floor:
+  // with one run per day, K=2 cannot resolve faster. Do not add a "huge jump"
+  // K=1 fast path — it would also fire on the 08-29 spike.
+  assert.deepEqual([...breachingOn(points, "2026-09-05")!], []);
+});
+
+test("Notte: from 09-06 the release breach stays open and is not re-alerted", async () => {
+  const points = await pointsFor("NOTTE");
+
+  for (const date of ["2026-09-06", "2026-09-07", "2026-09-08", "2026-09-09"]) {
+    assert.deepEqual(
+      [...breachingOn(points, date)!],
+      ["release"],
+      `expected a lone release breach on ${date}`
+    );
+  }
+
+  // Only 09-06 is an *edge*; the rest are silent.
+  const after0906 = openEvents(points).filter((e) => e > "2026-09-06/z");
+  assert.deepEqual(after0906, []);
+});
+
+test("Notte: the alert names the culprit phase, not the derived total", async () => {
+  const points = await pointsFor("NOTTE");
+  const breaching = breachingOn(points, "2026-09-09")!;
+
+  // total (383ms -> 1426ms) breaches too, but is suppressed so one root cause
+  // produces one alert.
+  assert.ok(breaching.has("release"));
+  assert.ok(!breaching.has("total"));
+});
+
+test("Notte: the regression cannot poison its own baseline", async () => {
+  const points = await pointsFor("NOTTE");
+  const index = points.findIndex((p) => p.date === "2026-09-09");
+  const series = evaluateSeries(
+    points.slice(0, index + 1),
+    { provider: "NOTTE", displayName: "Notte", concurrency: CONCURRENCY },
+    new Date("2026-09-09T12:00:00Z")
+  );
+
+  const release = series.breaches.find((b) => b.metric === "release");
+  assert.ok(release, "expected a release breach");
+
+  // Four regressed days sit inside the baseline window by 09-09, but the
+  // baseline is a median over 28 days, so it holds at the pre-regression value.
+  assert.ok(
+    release.baseline < 60,
+    `baseline drifted to ${release.baseline}ms — poisoning guard failed`
+  );
+  assert.ok(release.ratio > 10, `expected a large ratio, got ${release.ratio}`);
+  assert.equal(release.onsetDate, "2026-09-05");
+  assert.equal(series.status, "degraded");
+});
+
+test("Tilion: cold start, then noise floor, then the real jump", async () => {
+  const points = await pointsFor("TILION");
+
+  // Only 12 run-days of history. The first 9 cannot be judged at all, and
+  // `unknown` never pages — this is the cold-start guarantee for a newly
+  // added provider.
+  assert.equal(breachingOn(points, "2026-09-03"), null);
+
+  // release sits at 6-8ms for days: ratios touch 1.3x but the delta is ~2ms,
+  // so the absolute floor keeps it quiet.
+  assert.deepEqual([...breachingOn(points, "2026-09-07")!], []);
+
+  // 6.5ms -> 134ms is huge, but it is one day. Still silent, by design.
+  assert.deepEqual([...breachingOn(points, "2026-09-08")!], []);
+
+  // Second bad day: release (-> 85ms) and the success-rate collapse to 58%.
+  const latest = breachingOn(points, "2026-09-09")!;
+  assert.ok(latest.has("release"), "expected the real release jump to breach");
+  assert.ok(latest.has("successRate"), "expected the success-rate collapse to breach");
+});
+
+test("stale data is reported as stale, and staleness outranks degraded", async () => {
+  const points = await pointsFor("NOTTE");
+
+  // Same regressed data, evaluated a week later: the actionable fact becomes
+  // the dead cron, not the latency.
+  const series = evaluateSeries(
+    points,
+    { provider: "NOTTE", displayName: "Notte", concurrency: CONCURRENCY },
+    new Date("2026-09-16T12:00:00Z")
+  );
+  assert.equal(series.status, "stale");
+  assert.ok(series.ageHours! > DEFAULT_CONFIG.stalenessHours);
+});
+
+test("cold start reports unknown and never pages", async () => {
+  const points = await pointsFor("NOTTE");
+  const short = points.slice(0, DEFAULT_CONFIG.minBaselineDays + DEFAULT_CONFIG.recentDays - 1);
+
+  const series = evaluateSeries(
+    short,
+    { provider: "NEW", displayName: "New Provider", concurrency: CONCURRENCY },
+    new Date(`${short[short.length - 1].date}T12:00:00Z`)
+  );
+  assert.equal(series.status, "unknown");
+  assert.equal(series.reason, "insufficient_history");
+  assert.deepEqual(series.breaches, []);
+
+  assert.equal(breachingMetricsAt(short, short.length - 1), null);
+});
+
+test("no-data series is unknown, not a false alarm", () => {
+  const series = evaluateSeries(
+    [],
+    { provider: "EMPTY", displayName: "Empty", concurrency: CONCURRENCY },
+    new Date()
+  );
+  assert.equal(series.status, "unknown");
+  assert.equal(series.reason, "no_data");
+});

--- a/web/lib/regression.ts
+++ b/web/lib/regression.ts
@@ -1,0 +1,469 @@
+/**
+ * Latency-regression detector.
+ *
+ * Why this exists: on 2026-09-05 Notte's `session_release_ms` median jumped
+ * 25ms -> 1071ms and stayed there for five days before anyone noticed. Nothing
+ * in this repo watched for regressions, success-rate drops, or a dead cron.
+ *
+ * The hard requirement is telling a *sustained step change* (2026-09-05, alert)
+ * apart from a *one-day spike* (2026-08-29: creation 132->960, goto 85->622,
+ * normal again the next day — do NOT alert). A day-over-day comparison fires on
+ * the spike, trains everyone to ignore the channel, and still misses the real
+ * regression. Hence the K-of-N persistence rule below.
+ *
+ * Read `docs/regression-detection.md` before touching the thresholds.
+ */
+
+import {
+  loadHistoricalLeaderboard,
+  median,
+  type HistoricalLeaderboardResult,
+  type HistoricalProviderPoint,
+} from "./data";
+
+export type HealthStatus = "ok" | "degraded" | "stale" | "unknown";
+
+export type MetricKey =
+  | "creation"
+  | "connect"
+  | "goto"
+  | "release"
+  | "total"
+  | "successRate";
+
+export interface RegressionConfig {
+  /** Size of the recent window, in run-days. */
+  recentDays: number;
+  /** How many of `recentDays` must breach before we call it a regression. */
+  minBreachDays: number;
+  /** Size of the baseline window, in run-days. */
+  baselineDays: number;
+  /** Baseline must clear at least this many days or we report `unknown`. */
+  minBaselineDays: number;
+  /** A day breaches only if current/baseline >= this... */
+  minRatio: number;
+  /** ...AND current-baseline >= this. Both, always. */
+  minAbsMs: number;
+  /** Success-rate drop, in percentage points, that counts as a breach. */
+  successRateDropPts: number;
+  /** ...and the absolute ceiling below which a drop counts at all. */
+  successRateFloor: number;
+  /** Hours since the last recorded run before a provider is `stale`. */
+  stalenessHours: number;
+}
+
+export const DEFAULT_CONFIG: RegressionConfig = {
+  recentDays: 3,
+  minBreachDays: 2,
+  baselineDays: 28,
+  minBaselineDays: 7,
+  minRatio: 1.5,
+  minAbsMs: 50,
+  successRateDropPts: 5,
+  successRateFloor: 95,
+  stalenessHours: 36,
+};
+
+interface MetricSpec {
+  key: MetricKey;
+  unit: "ms" | "percent";
+  /** "up" = higher is worse (latency). "down" = lower is worse (success rate). */
+  direction: "up" | "down";
+  label: string;
+}
+
+export const METRIC_SPECS: MetricSpec[] = [
+  { key: "creation", unit: "ms", direction: "up", label: "session creation" },
+  { key: "connect", unit: "ms", direction: "up", label: "CDP connect" },
+  { key: "goto", unit: "ms", direction: "up", label: "page goto" },
+  { key: "release", unit: "ms", direction: "up", label: "session release" },
+  { key: "total", unit: "ms", direction: "up", label: "total" },
+  { key: "successRate", unit: "percent", direction: "down", label: "success rate" },
+];
+
+const METRIC_BY_KEY = new Map(METRIC_SPECS.map((s) => [s.key, s]));
+
+/** Latency phases only — `total` is derived from these, `successRate` is not a phase. */
+const PHASE_KEYS: MetricKey[] = ["creation", "connect", "goto", "release"];
+
+export function metricValue(
+  point: HistoricalProviderPoint,
+  metric: MetricKey
+): number {
+  switch (metric) {
+    case "creation":
+      return point.medianCreationMs;
+    case "connect":
+      return point.medianConnectMs;
+    case "goto":
+      return point.medianGotoMs;
+    case "release":
+      return point.medianReleaseMs;
+    case "total":
+      return point.totalTimeMs;
+    case "successRate":
+      return point.successRate;
+  }
+}
+
+export interface MetricVerdict {
+  metric: MetricKey;
+  label: string;
+  unit: "ms" | "percent";
+  /** Median of daily medians across the baseline window. */
+  baseline: number;
+  /** Median of daily values across the recent window. */
+  current: number;
+  ratio: number;
+  delta: number;
+  breachDays: number;
+  breached: boolean;
+  /** Date the current run of consecutive breaching days began. */
+  onsetDate: string | null;
+  /** How many consecutive days back the breach extends. */
+  breachAgeDays: number;
+  recent: { date: string; value: number; breached: boolean }[];
+  /** Last 14 daily values, oldest first. */
+  sparkline: { date: string; value: number }[];
+}
+
+export interface SeriesHealth {
+  provider: string;
+  displayName: string;
+  concurrency: number;
+  status: HealthStatus;
+  /** Set when status is `unknown`: why we could not judge. */
+  reason: "no_data" | "insufficient_history" | null;
+  lastRunDate: string | null;
+  lastRunAt: string | null;
+  ageHours: number | null;
+  daysOfHistory: number;
+  metrics: MetricVerdict[];
+  /** The breached subset of `metrics`, worst first. */
+  breaches: MetricVerdict[];
+  summary: string;
+}
+
+export interface HealthReport {
+  status: HealthStatus;
+  summary: string;
+  benchmark: "hello-browser";
+  concurrency: number;
+  evaluatedAt: string;
+  config: RegressionConfig;
+  /** Providers whose latest run is older than `stalenessHours`. */
+  stale: string[];
+  series: SeriesHealth[];
+}
+
+function resolveConfig(partial?: Partial<RegressionConfig>): RegressionConfig {
+  return { ...DEFAULT_CONFIG, ...partial };
+}
+
+/**
+ * Windows are POSITIONAL (run-days), not calendar days. Providers have gaps in
+ * their history — calendar arithmetic would silently produce short or empty
+ * windows on either side of a gap.
+ *
+ * The baseline stops one full recent-window short of `index`, so a persisting
+ * regression can never contribute to the baseline it is measured against.
+ */
+function windowsAt(
+  points: HistoricalProviderPoint[],
+  index: number,
+  config: RegressionConfig
+) {
+  const recentStart = index - config.recentDays + 1;
+  const recent = points.slice(Math.max(0, recentStart), index + 1);
+  const baselineEnd = Math.max(0, recentStart);
+  const baseline = points.slice(
+    Math.max(0, baselineEnd - config.baselineDays),
+    baselineEnd
+  );
+  return { recent, baseline };
+}
+
+function isBreachingDay(
+  value: number,
+  baseline: number,
+  spec: MetricSpec,
+  config: RegressionConfig
+): boolean {
+  if (spec.direction === "up") {
+    // Dual threshold. The ratio alone would fire on a 6ms -> 10ms wobble; the
+    // absolute floor alone would fire on any slow-but-stable phase.
+    if (baseline <= 0) return false;
+    return value >= baseline * config.minRatio && value - baseline >= config.minAbsMs;
+  }
+  return (
+    value <= baseline - config.successRateDropPts && value < config.successRateFloor
+  );
+}
+
+/**
+ * The set of metrics breaching as of `index`, or `null` when there is not
+ * enough history to judge. This is the primitive the edge-triggered Slack
+ * dedup diffs against `index - 1`.
+ */
+export function breachingMetricsAt(
+  points: HistoricalProviderPoint[],
+  index: number,
+  partial?: Partial<RegressionConfig>
+): Set<MetricKey> | null {
+  const config = resolveConfig(partial);
+  if (index < 0 || index >= points.length) return null;
+
+  const { recent, baseline } = windowsAt(points, index, config);
+  if (recent.length < config.recentDays) return null;
+  if (baseline.length < config.minBaselineDays) return null;
+
+  const breaching = new Set<MetricKey>();
+  for (const spec of METRIC_SPECS) {
+    const baselineValue = median(baseline.map((p) => metricValue(p, spec.key)));
+    const breachDays = recent.filter((p) =>
+      isBreachingDay(metricValue(p, spec.key), baselineValue, spec, config)
+    ).length;
+    if (breachDays >= config.minBreachDays) breaching.add(spec.key);
+  }
+
+  // `total` is the sum of the phases. When a phase already fired, reporting
+  // `total` too turns one root cause into two alerts naming the same event.
+  if (breaching.size > 1 && PHASE_KEYS.some((k) => breaching.has(k))) {
+    breaching.delete("total");
+  }
+  return breaching;
+}
+
+function buildVerdict(
+  points: HistoricalProviderPoint[],
+  index: number,
+  spec: MetricSpec,
+  config: RegressionConfig,
+  breached: boolean
+): MetricVerdict {
+  const { recent, baseline } = windowsAt(points, index, config);
+  const baselineValue = median(baseline.map((p) => metricValue(p, spec.key)));
+  const currentValue = median(recent.map((p) => metricValue(p, spec.key)));
+
+  const recentDetail = recent.map((p) => ({
+    date: p.date,
+    value: metricValue(p, spec.key),
+    breached: isBreachingDay(metricValue(p, spec.key), baselineValue, spec, config),
+  }));
+
+  // Walk backwards from `index` while days keep breaching, to find when this
+  // episode started. Reported as the onset date in the alert.
+  let breachAgeDays = 0;
+  let onsetDate: string | null = null;
+  for (let i = index; i >= 0; i--) {
+    if (!isBreachingDay(metricValue(points[i], spec.key), baselineValue, spec, config)) {
+      break;
+    }
+    breachAgeDays++;
+    onsetDate = points[i].date;
+  }
+
+  const sparkline = points
+    .slice(Math.max(0, index - 13), index + 1)
+    .map((p) => ({ date: p.date, value: metricValue(p, spec.key) }));
+
+  const ratio = baselineValue > 0 ? currentValue / baselineValue : 0;
+
+  return {
+    metric: spec.key,
+    label: spec.label,
+    unit: spec.unit,
+    baseline: baselineValue,
+    current: currentValue,
+    ratio,
+    delta: currentValue - baselineValue,
+    breachDays: recentDetail.filter((r) => r.breached).length,
+    breached,
+    onsetDate,
+    breachAgeDays,
+    recent: recentDetail,
+    sparkline,
+  };
+}
+
+function formatMs(value: number): string {
+  return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`;
+}
+
+function describeVerdict(v: MetricVerdict): string {
+  if (v.unit === "percent") {
+    return `${v.label} ${v.baseline.toFixed(1)}% -> ${v.current.toFixed(1)}%`;
+  }
+  return `${v.label} ${formatMs(v.baseline)} -> ${formatMs(v.current)} (${v.ratio.toFixed(1)}x)`;
+}
+
+export function evaluateSeries(
+  points: HistoricalProviderPoint[],
+  meta: { provider: string; displayName: string; concurrency: number },
+  now: Date,
+  partial?: Partial<RegressionConfig>
+): SeriesHealth {
+  const config = resolveConfig(partial);
+  const base = {
+    provider: meta.provider,
+    displayName: meta.displayName,
+    concurrency: meta.concurrency,
+    daysOfHistory: points.length,
+  };
+
+  if (points.length === 0) {
+    return {
+      ...base,
+      status: "unknown",
+      reason: "no_data",
+      lastRunDate: null,
+      lastRunAt: null,
+      ageHours: null,
+      metrics: [],
+      breaches: [],
+      summary: `${meta.displayName}: no data`,
+    };
+  }
+
+  const index = points.length - 1;
+  const latest = points[index];
+  const lastRunAt = latest.lastEntryAt ?? `${latest.date}T00:00:00.000Z`;
+  const ageHours = (now.getTime() - Date.parse(lastRunAt)) / 3_600_000;
+  const stale = ageHours > config.stalenessHours;
+
+  const breaching = breachingMetricsAt(points, index, config);
+
+  if (breaching === null) {
+    // Cold start: a new provider is `unknown` until it has enough history, and
+    // `unknown` never pages.
+    return {
+      ...base,
+      status: stale ? "stale" : "unknown",
+      reason: "insufficient_history",
+      lastRunDate: latest.date,
+      lastRunAt,
+      ageHours,
+      metrics: [],
+      breaches: [],
+      summary: stale
+        ? `${meta.displayName}: no results for ${Math.round(ageHours)}h`
+        : `${meta.displayName}: only ${points.length} run-days of history, need ${
+            config.minBaselineDays + config.recentDays
+          }`,
+    };
+  }
+
+  const metrics = METRIC_SPECS.map((spec) =>
+    buildVerdict(points, index, spec, config, breaching.has(spec.key))
+  );
+  const breaches = metrics
+    .filter((m) => m.breached)
+    .sort((a, b) => b.ratio - a.ratio);
+
+  // Staleness wins over degraded on purpose: if the cron died, the latency
+  // numbers are stale too, and the actionable fact is the dead cron.
+  const status: HealthStatus = stale
+    ? "stale"
+    : breaches.length > 0
+      ? "degraded"
+      : "ok";
+
+  let summary: string;
+  if (stale) {
+    summary = `${meta.displayName}: no results for ${Math.round(ageHours)}h (last ${latest.date})`;
+  } else if (breaches.length > 0) {
+    const worst = breaches[0];
+    const since = worst.onsetDate ? ` since ${worst.onsetDate}` : "";
+    summary = `${meta.displayName} ${describeVerdict(worst)}${since}`;
+    if (breaches.length > 1) summary += ` (+${breaches.length - 1} more)`;
+  } else {
+    summary = `${meta.displayName}: ok`;
+  }
+
+  return {
+    ...base,
+    status,
+    reason: null,
+    lastRunDate: latest.date,
+    lastRunAt,
+    ageHours,
+    metrics,
+    breaches,
+    summary,
+  };
+}
+
+const STATUS_RANK: Record<HealthStatus, number> = {
+  ok: 0,
+  unknown: 1,
+  degraded: 2,
+  stale: 3,
+};
+
+export function evaluateHistory(
+  history: HistoricalLeaderboardResult,
+  concurrency: number,
+  now: Date,
+  partial?: Partial<RegressionConfig>
+): HealthReport {
+  const config = resolveConfig(partial);
+  const series = history.providers
+    .map((p) =>
+      evaluateSeries(
+        p.points,
+        { provider: p.provider, displayName: p.displayName, concurrency },
+        now,
+        config
+      )
+    )
+    .sort((a, b) => STATUS_RANK[b.status] - STATUS_RANK[a.status]);
+
+  const status = series.reduce<HealthStatus>(
+    (worst, s) => (STATUS_RANK[s.status] > STATUS_RANK[worst] ? s.status : worst),
+    "ok"
+  );
+
+  const stale = series.filter((s) => s.status === "stale").map((s) => s.provider);
+  const degraded = series.filter((s) => s.status === "degraded");
+
+  let summary: string;
+  if (series.length === 0) {
+    summary = "no providers";
+  } else if (stale.length > 0) {
+    summary = `stale: ${stale.join(", ")}`;
+  } else if (degraded.length > 0) {
+    summary = degraded.map((s) => s.summary).join("; ");
+  } else {
+    summary = `all ${series.length} providers within baseline`;
+  }
+
+  return {
+    status,
+    summary,
+    benchmark: "hello-browser",
+    concurrency,
+    evaluatedAt: now.toISOString(),
+    config,
+    stale,
+    series,
+  };
+}
+
+/**
+ * Loads history off disk (or the GitHub fallback) and evaluates it.
+ *
+ * `results/` is traced into the Vercel lambda bundle — verified via
+ * `.next/server/app/api/**\/*.nft.json`, which lists ~3k `results/` files — so
+ * this works at request time and the clock is the request's, not the build's.
+ * That matters: a dead cron produces no commit, so no rebuild, so a build-time
+ * clock could never notice its own data aging.
+ */
+export async function loadHealthReport(
+  benchmark: "hello-browser",
+  concurrency: number,
+  now: Date,
+  partial?: Partial<RegressionConfig>
+): Promise<HealthReport> {
+  const history = await loadHistoricalLeaderboard(benchmark, concurrency);
+  return evaluateHistory(history, concurrency, now, partial);
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "shadcn": "^4.14.0",
         "tailwindcss": "^4.3.2",
+        "tsx": "^4.23.13",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }
@@ -671,6 +672,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -834,9 +1277,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -852,9 +1292,6 @@
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -872,9 +1309,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -890,9 +1324,6 @@
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -910,9 +1341,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -928,9 +1356,6 @@
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -948,9 +1373,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -967,9 +1389,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -985,9 +1404,6 @@
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1011,9 +1427,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1035,9 +1448,6 @@
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1061,9 +1471,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1085,9 +1492,6 @@
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1111,9 +1515,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1136,9 +1537,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1160,9 +1558,6 @@
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1407,9 +1802,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,9 +1817,6 @@
       "integrity": "sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1445,9 +1834,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1463,9 +1849,6 @@
       "integrity": "sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3284,9 +3667,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3304,9 +3684,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3324,9 +3701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3344,9 +3718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4575,6 +4946,48 @@
         "tests/browser-compat"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4888,6 +5301,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5660,9 +6088,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5684,9 +6109,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5708,9 +6130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5732,9 +6151,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7456,6 +7872,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4104,9 +4104,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4181,9 +4181,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4201,11 +4201,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4282,9 +4282,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001776",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4844,9 +4844,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -4922,9 +4922,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5483,9 +5483,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6514,11 +6514,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -6797,9 +6800,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6878,13 +6881,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7520,15 +7524,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7540,14 +7544,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8000,9 +8004,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "check-regressions": "tsx scripts/check-regressions.ts",
+    "test": "tsx --test lib/*.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
@@ -26,6 +28,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "shadcn": "^4.14.0",
     "tailwindcss": "^4.3.2",
+    "tsx": "^4.23.13",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   },

--- a/web/scripts/check-regressions.ts
+++ b/web/scripts/check-regressions.ts
@@ -316,7 +316,10 @@ async function runOne(
     const isStale = series.status === "stale";
 
     if (options.mode === "digest") {
-      if (series.breaches.length > 0) {
+      // Skip stale providers: their breach numbers describe old data, and the
+      // staleness message below is the one that matters. Reporting both would
+      // call a regression active in the same run that says the data is stale.
+      if (!isStale && series.breaches.length > 0) {
         await post(openedMessage(series, series.breaches, sha), options);
         events++;
       }

--- a/web/scripts/check-regressions.ts
+++ b/web/scripts/check-regressions.ts
@@ -1,0 +1,376 @@
+/**
+ * Regression alerter. Run by .github/workflows/regression-alert.yml, and by
+ * hand for debugging or replay.
+ *
+ *   npx tsx scripts/check-regressions.ts --dry-run
+ *   npx tsx scripts/check-regressions.ts --as-of 2026-09-06 --dry-run
+ *
+ * Dedup is edge-triggered and stateless. The detector is a pure function of
+ * committed data, so diffing "what is breaching today" against "what was
+ * breaching yesterday" yields exact open/close events with no state file, no
+ * commit-back to main (which would race the two EC2 boxes' push-retry loop),
+ * and no cache to evict. It is also replayable: `--as-of` reproduces any past
+ * day's decision exactly.
+ */
+
+import {
+  breachingMetricsAt,
+  evaluateSeries,
+  DEFAULT_CONFIG,
+  METRIC_SPECS,
+  type MetricKey,
+  type MetricVerdict,
+  type SeriesHealth,
+} from "../lib/regression";
+import { loadHistoricalLeaderboard } from "../lib/data";
+import type { HistoricalProviderPoint } from "../lib/data-shared";
+
+type Mode = "edge" | "staleness" | "digest";
+
+interface Options {
+  asOf: string | null;
+  dryRun: boolean;
+  /** The explicit --dry-run flag, distinct from "no webhook configured". */
+  dryRunFlag: boolean;
+  concurrency: number[];
+  mode: Mode;
+  providers: string[] | null;
+  strict: boolean;
+}
+
+const SITE = "https://www.browserarena.ai";
+
+function parseArgs(argv: string[]): Options {
+  const get = (flag: string): string | null => {
+    const i = argv.indexOf(flag);
+    return i >= 0 && argv[i + 1] ? argv[i + 1] : null;
+  };
+  const providers = get("--providers");
+  return {
+    asOf: get("--as-of"),
+    dryRun: argv.includes("--dry-run") || !process.env.SLACK_WEBHOOK_URL,
+    dryRunFlag: argv.includes("--dry-run"),
+    concurrency: (get("--concurrency") ?? "1")
+      .split(",")
+      .map((c) => Number(c.trim()))
+      .filter((c) => Number.isFinite(c)),
+    mode: (get("--mode") as Mode | null) ?? "edge",
+    providers: providers
+      ? providers.split(",").map((p) => p.trim().toUpperCase()).filter(Boolean)
+      : null,
+    strict: argv.includes("--strict"),
+  };
+}
+
+/**
+ * Alerting scope. The detector evaluates every provider regardless; this only
+ * decides who gets a message. `null` means every provider ("all").
+ */
+function alertProviders(options: Options): Set<string> | null {
+  const fromEnv = process.env.ALERT_PROVIDERS?.split(",")
+    .map((p) => p.trim().toUpperCase())
+    .filter(Boolean);
+  const names = options.providers ?? fromEnv ?? ["NOTTE"];
+  if (names.some((n) => n === "ALL")) return null;
+  return new Set(names);
+}
+
+const SPARK = "▁▂▃▄▅▆▇█";
+
+function sparkline(values: number[]): string {
+  if (values.length === 0) return "";
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (max === min) return SPARK[0].repeat(values.length);
+  return values
+    .map((v) => SPARK[Math.min(SPARK.length - 1, Math.floor(((v - min) / (max - min)) * (SPARK.length - 1)))])
+    .join("");
+}
+
+function fmt(v: MetricVerdict, value: number): string {
+  if (v.unit === "percent") return `${value.toFixed(1)}%`;
+  return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`;
+}
+
+function metricLine(v: MetricVerdict): string {
+  const head =
+    v.unit === "percent"
+      ? `*${v.label}*  ${fmt(v, v.baseline)} → ${fmt(v, v.current)}  (${v.delta.toFixed(1)} pts)`
+      : `*${v.label}*  ${fmt(v, v.baseline)} → ${fmt(v, v.current)}  *${v.ratio.toFixed(1)}×*  (+${fmt(v, v.delta)})`;
+  const spark = sparkline(v.sparkline.map((s) => s.value));
+  const nums = v.sparkline
+    .slice(-7)
+    .map((s) => Math.round(s.value))
+    .join(" ");
+  return [
+    head,
+    `breached ${v.breachDays} of the last ${DEFAULT_CONFIG.recentDays} days` +
+      (v.onsetDate ? ` · first bad day ${v.onsetDate}` : ""),
+    "`" + spark + "`  " + nums,
+  ].join("\n");
+}
+
+interface SlackBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+function openedMessage(series: SeriesHealth, opened: MetricVerdict[], sha: string | undefined) {
+  const worst = opened[0];
+  const severe = worst.metric === "successRate" || worst.ratio >= 3;
+  const blocks: SlackBlock[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `${severe ? "🚨" : "⚠️"} Regression — ${series.displayName} (hello-browser, c${series.concurrency})`,
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: opened.map(metricLine).join("\n\n") },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text:
+            `Baseline = median of daily medians over ${DEFAULT_CONFIG.baselineDays} run-days, ` +
+            `offset ${DEFAULT_CONFIG.recentDays} days back · ` +
+            `last run ${series.lastRunDate} · ${series.daysOfHistory} days of history`,
+        },
+      ],
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "View chart" },
+          url: `${SITE}/?concurrency=${series.concurrency}`,
+        },
+        ...(sha
+          ? [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "Results commit" },
+                url: `https://github.com/nottelabs/browserarena/commit/${sha}`,
+              },
+            ]
+          : []),
+      ],
+    },
+  ];
+  return { text: `Regression: ${series.summary}`, blocks };
+}
+
+function recoveredMessage(series: SeriesHealth, closed: MetricKey[]) {
+  const labels = closed
+    .map((k) => METRIC_SPECS.find((s) => s.key === k)?.label ?? k)
+    .join(", ");
+  return {
+    text: `Recovered: ${series.displayName} ${labels}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `✅ *${series.displayName}* (c${series.concurrency}) — ${labels} back within baseline as of ${series.lastRunDate}.`,
+        },
+      },
+    ],
+  };
+}
+
+function staleMessage(series: SeriesHealth, healthy: string[]) {
+  return {
+    text: `No results for ${series.displayName} in ${Math.round(series.ageHours ?? 0)}h`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `⚠️ *No results for ${series.displayName} in ${Math.round(series.ageHours ?? 0)}h*\n` +
+            `Last run \`${series.lastRunDate}\` (expected daily). ` +
+            `Check the EC2 cron and \`logs/\`.`,
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: healthy.length
+              ? `Reporting normally: ${healthy.join(", ")}`
+              : "No provider reported — both runners may be down.",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function post(payload: unknown, options: Options): Promise<void> {
+  if (options.dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  const res = await fetch(process.env.SLACK_WEBHOOK_URL!, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`Slack POST failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function main(): Promise<number> {
+  const options = parseArgs(process.argv.slice(2));
+
+  // Fail loudly, and immediately, if this run was supposed to be able to post
+  // but has no webhook. Otherwise a rotated or deleted secret degrades into a
+  // green workflow that silently reaches nobody — the same class of failure
+  // this whole system exists to catch.
+  if (
+    !options.dryRunFlag &&
+    process.env.ALERT_REQUIRE_WEBHOOK === "true" &&
+    !process.env.SLACK_WEBHOOK_URL
+  ) {
+    console.error(
+      "[check-regressions] SLACK_WEBHOOK_URL is not set but this run is expected " +
+        "to post. Alerts would be silently dropped. Set the repo secret, or pass " +
+        "--dry-run."
+    );
+    return 1;
+  }
+
+  const scope = alertProviders(options);
+  let events = 0;
+  for (const [i, concurrency] of options.concurrency.entries()) {
+    events += await runOne(options, scope, concurrency, i === 0);
+  }
+  return options.strict && events > 0 ? 1 : 0;
+}
+
+async function runOne(
+  options: Options,
+  scope: Set<string> | null,
+  concurrency: number,
+  isPrimaryLevel: boolean
+): Promise<number> {
+  const history = await loadHistoricalLeaderboard("hello-browser", concurrency);
+
+  // `--as-of` truncates history so a past day's decision replays exactly.
+  const truncate = (points: HistoricalProviderPoint[]) =>
+    options.asOf ? points.filter((p) => p.date <= options.asOf!) : points;
+
+  const now = options.asOf
+    ? new Date(`${options.asOf}T23:59:59.000Z`)
+    : new Date();
+
+  let events = 0;
+  const healthy: string[] = [];
+  const staleSeries: SeriesHealth[] = [];
+  const pending: { series: SeriesHealth; opened: MetricVerdict[]; closed: MetricKey[] }[] = [];
+
+  for (const provider of history.providers) {
+    const points = truncate(provider.points);
+    const series = evaluateSeries(
+      points,
+      {
+        provider: provider.provider,
+        displayName: provider.displayName,
+        concurrency,
+      },
+      now
+    );
+
+    if (series.status === "stale") staleSeries.push(series);
+    else healthy.push(provider.displayName);
+
+    if (scope && !scope.has(provider.provider)) continue;
+
+    const n = points.length;
+    const today = breachingMetricsAt(points, n - 1);
+    const yesterday = breachingMetricsAt(points, n - 2);
+    if (today === null) continue;
+
+    const opened = [...today].filter((m) => !yesterday?.has(m));
+    const closed = yesterday ? [...yesterday].filter((m) => !today.has(m)) : [];
+    pending.push({
+      series,
+      opened: series.metrics
+        .filter((m) => opened.includes(m.metric))
+        .sort((a, b) => b.ratio - a.ratio),
+      closed,
+    });
+  }
+
+  const sha = process.env.GITHUB_SHA;
+
+  for (const { series, opened, closed } of pending) {
+    const isStale = series.status === "stale";
+
+    if (options.mode === "digest") {
+      if (series.breaches.length > 0) {
+        await post(openedMessage(series, series.breaches, sha), options);
+        events++;
+      }
+      continue;
+    }
+
+    if (options.mode === "edge" && !isStale) {
+      if (opened.length > 0) {
+        await post(openedMessage(series, opened, sha), options);
+        events++;
+      }
+      if (closed.length > 0) {
+        await post(recoveredMessage(series, closed), options);
+        events++;
+      }
+    }
+  }
+
+  // Staleness is checked in every mode: a dead cron produces no commit, so the
+  // push trigger never fires and only the scheduled run can catch it. It is a
+  // property of the runner, not of a concurrency level, so it is reported once.
+  for (const series of isPrimaryLevel ? staleSeries : []) {
+    if (scope && !scope.has(series.provider)) continue;
+    await post(
+      staleMessage(
+        series,
+        healthy.filter((h) => h !== series.displayName)
+      ),
+      options
+    );
+    events++;
+  }
+
+  const summary = pending
+    .map((p) => {
+      const parts = [
+        p.opened.length ? `opened=${p.opened.map((m) => m.metric).join(",")}` : null,
+        p.closed.length ? `closed=${p.closed.join(",")}` : null,
+      ].filter(Boolean);
+      return `${p.series.provider}: ${parts.length ? parts.join(" ") : "no change"} (${p.series.status})`;
+    })
+    .join("\n");
+  console.error(
+    `[check-regressions] mode=${options.mode} c${concurrency}` +
+      `${options.asOf ? ` as-of=${options.asOf}` : ""} events=${events}\n${summary}`
+  );
+
+  return events;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err);
+    process.exit(2);
+  }
+);

--- a/web/scripts/check-regressions.ts
+++ b/web/scripts/check-regressions.ts
@@ -40,6 +40,24 @@ interface Options {
 
 const SITE = "https://www.browserarena.ai";
 
+/**
+ * A shape check alone would accept an impossible date like 2026-99-99, which
+ * becomes an Invalid Date, makes `ageHours` NaN, and silently disables
+ * staleness detection. Round-tripping through Date catches that, and 2026-02-30.
+ */
+function parseAsOf(raw: string | null): string | null {
+  if (raw === null) return null;
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(raw) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== raw
+  ) {
+    throw new Error(`Invalid --as-of date: ${raw} (expected a real YYYY-MM-DD)`);
+  }
+  return raw;
+}
+
 function parseArgs(argv: string[]): Options {
   const get = (flag: string): string | null => {
     const i = argv.indexOf(flag);
@@ -47,7 +65,7 @@ function parseArgs(argv: string[]): Options {
   };
   const providers = get("--providers");
   return {
-    asOf: get("--as-of"),
+    asOf: parseAsOf(get("--as-of")),
     dryRun: argv.includes("--dry-run") || !process.env.SLACK_WEBHOOK_URL,
     dryRunFlag: argv.includes("--dry-run"),
     concurrency: (get("--concurrency") ?? "1")


### PR DESCRIPTION
## Why

On **2026-09-05 Notte's `session_release_ms` median jumped 25ms → 1071ms** and stayed there for five days before anyone noticed. The repo had zero alerting — nothing watched for latency regressions, success-rate drops, or a benchmark cron dying silently.

There was also no way to ask. `/api/leaderboard/*` only ever serves the latest date, and `loadHistoricalLeaderboard` computes full history but was consumed only by `page.tsx`.

## The detection problem

The hard part is separating a **sustained step change** (09-05 — alert) from a **one-day spike** (08-29: creation 132→960, goto 85→622, normal again the next day — do not alert). A day-over-day check fires on the spike, trains everyone to ignore the channel, and still misses the real regression.

A metric breaches only when **2 of the last 3 run-days** exceed a **28-run-day median-of-medians baseline** by **both 1.5× and 50ms**. The baseline is offset 3 days back so a persisting regression cannot poison the baseline it's measured against. Windows are positional, not calendar-based, because providers have gaps.

### Calibration

Replayed over all 121 run-days of Notte history, this produces **two** alerts:

```
2026-08-20/goto
2026-09-06/release   <- the incident, caught 1 day after onset
```

Silent on 08-29 and 09-01. `web/lib/regression.test.ts` pins that list, so a threshold change shows up as a test diff rather than a surprise.

## What's here

| File | |
|---|---|
| `web/lib/regression.ts` | detector, plus staleness and success-rate checks |
| `web/app/api/health/route.ts` | `200 ok` / `503 degraded` — any uptime monitor alerts on it with no custom code |
| `web/scripts/check-regressions.ts` | Slack alerter with `--as-of` replay |
| `.github/workflows/regression-alert.yml` | push (edge), daily cron (staleness), Monday (digest) |
| `docs/regression-detection.md` | thresholds, calibration, monitor setup, known limits |

Upstream changes are minimal: `median` exported, one optional `lastEntryAt` field on `HistoricalProviderPoint`.

Dedup is **stateless and edge-triggered** — diffing today's breach set against yesterday's gives exact open/close events. No state file, no `contents: write`, and it can't race the two EC2 runners' push-retry loop. The five-day incident produces exactly one message.

```console
$ curl -s -o /dev/null -w '%{http_code}\n' https://www.browserarena.ai/api/health
503
$ curl -s https://www.browserarena.ai/api/health | jq -r .summary
Notte session release 26ms -> 1.07s (41.2x) since 2026-09-05
```

## Verification

- 11 tests pass; `npm test` added to CI
- `next build` and root `tsc` both clean
- Endpoint exercised against a production build across the full param matrix, including 400s
- Confirmed `results/` is traced into the health route's lambda bundle (3,016 files), so `fs` works at request time — the route is dynamic, so the staleness clock is the request's

## Known limits (documented, deliberate)

- **24h detection floor.** With one run/day, 2-of-3 can't be faster. Do not add a K=1 fast path — it would also fire on the 08-29 spike.
- **Gradual drift is not detected.** ≤2%/day compounding never fires, since the rolling baseline drifts with it. Deprioritized for now.
- **Self-clearing.** The current Notte breach will report `ok` again on ~2026-09-22 without anything being fixed, once enough regressed days enter the baseline. Green means "no longer anomalous", not "resolved".

## Before merging

**Add the `SLACK_WEBHOOK_URL` repo secret.** Without it nothing reaches Slack. In the upstream repo the workflow sets `ALERT_REQUIRE_WEBHOOK=true` so a missing secret fails the run loudly rather than degrading into a green workflow that reaches nobody; forks stay green.

Note the endpoint returns 503 for Notte today, correctly — the release regression is real and ongoing. Also surfaced and currently outside the Notte-only alert scope: **Browserbase** connect 313ms → 879ms since 09-01, and **Tilion** release 7ms → 85ms with success rate at 58% since 09-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
